### PR TITLE
remove default_login override

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,7 +56,6 @@ class pulp (
 
   $ssl_ca_cert = '/etc/pki/tls/certs/pulp_ssl_cert.crt',
 
-  $default_login = $pulp::params::default_login,
   $default_password = $pulp::params::default_password,
 
   $repo_auth = true,
@@ -64,6 +63,8 @@ class pulp (
   $reset_data = false,
   $reset_cache = false
   ) inherits pulp::params {
+
+  $default_login = $pulp::params::default_login
 
   include apache
 


### PR DESCRIPTION
Corresponds to https://github.com/Katello/katello/pull/3584 which solidifies the change in the way
the first user is created, in that it uses the pulp 'admin' user to create the first user instead of making
the first pulp 'admin' user have the same username as the first user.
