### PR TITLE
Fixing #5299: variables not used properly.

### DIFF
--- a/templates/etc/pulp/server.conf.erb
+++ b/templates/etc/pulp/server.conf.erb
@@ -37,7 +37,7 @@ operation_retries: 2
 # debugging_mode: boolean; toggles Pulp's debugging capabilities
 
 [server]
-server_name: <%= (has_variable?("fqdn") ? fqdn : hostname).downcase %>
+server_name: <%= (has_variable?("fqdn") ? @fqdn : @hostname).downcase %>
 key_url: /pulp/gpg
 ks_url: /pulp/ks
 default_login: <%= @default_login %>
@@ -279,7 +279,7 @@ dispatch_interval: 30
 # sync_weight: concurrency weight of repository sync tasks
 
 [tasks]
-concurrency_threshold: <%= processorcount.to_i + 1 %>
+concurrency_threshold: <%= @processorcount.to_i + 1 %>
 dispatch_interval: 0.5
 archived_call_lifetime: 48
 consumer_content_weight: 0


### PR DESCRIPTION
While installing katello 'community' nighty today I noticed a few errors
related to how certain variables were being refered to in a couple of
templates:

``` bash
Variable access via 'fqdn' is deprecated. Use '@fqdn' instead.
template[/usr/share/katello-installer/modules/certs/templates/rhsm-katello-reconfigure.erb]:19
Variable access via 'fqdn' is deprecated. Use '@fqdn' instead.
template[/usr/share/katello-installer/modules/pulp/templates/etc/pulp/server.conf.erb]:40
Variable access via 'processorcount' is deprecated. Use
'@processorcount' instead.
template[/usr/share/katello-installer/modules/pulp/templates/etc/pulp/server.conf.erb]:282
```

This pull request should fix these variables
