### PR TITLE
Refs #6360 - enable pulp_manage_puppet selinux boolean

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,6 +1,12 @@
 # Pulp Master Configuration
 class pulp::config {
 
+  exec {'selinux_pulp_manage_puppet':
+    command => 'semanage boolean -m --on pulp_manage_puppet',
+    path    => '/sbin:/usr/sbin:/bin:/usr/bin',
+    onlyif  => 'getsebool pulp_manage_puppet | grep off',
+  }
+
   file {'/var/lib/pulp/packages':
     ensure => directory,
     owner  => 'apache',


### PR DESCRIPTION
Tested with ad-hoc puppet command:

```
puppet apply -e "  exec {'selinux_pulp_manage_puppet':
    command => 'semanage boolean -m --on pulp_manage_puppet',
    path    => '/sbin:/usr/sbin:/bin:/usr/bin',
    onlyif  => 'getsebool pulp_manage_puppet | grep off',
  }
" -v --debug
```

Please confirm that this gets called AFTER pulp (thus pulp-selinux) is
installed. If not, I need to add a require. But I think it should be
fine. Double-check.

It works fine even when this flag is not available (it skips).
