### PR TITLE
Fixes #6530: Ensure proxy configs work if not all values specified.

### DIFF
--- a/templates/iso_importer.json
+++ b/templates/iso_importer.json
@@ -1,14 +1,6 @@
 {
-    <%- if @proxy_url %>
     "proxy_host": "<%= @proxy_url %>",
-    <% end %>
-    <%- if @proxy_port %>
     "proxy_port": "<%= @proxy_port %>",
-    <% end %>
-    <%- if @proxy_username %>
     "proxy_username": "<%= @proxy_username %>",
-    <% end %>
-    <%- if @proxy_password %>
     "proxy_password": "<%= @proxy_password %>"
-    <% end %>
 }

--- a/templates/puppet_importer.json
+++ b/templates/puppet_importer.json
@@ -1,14 +1,6 @@
 {
-    <%- if @proxy_url %>
     "proxy_host": "<%= @proxy_url %>",
-    <% end %>
-    <%- if @proxy_port %>
     "proxy_port": "<%= @proxy_port %>",
-    <% end %>
-    <%- if @proxy_username %>
     "proxy_username": "<%= @proxy_username %>",
-    <% end %>
-    <%- if @proxy_password %>
     "proxy_password": "<%= @proxy_password %>"
-    <% end %>
 }

--- a/templates/yum_importer.json
+++ b/templates/yum_importer.json
@@ -1,14 +1,6 @@
 {
-    <%- if @proxy_url %>
     "proxy_host": "<%= @proxy_url %>",
-    <% end %>
-    <%- if @proxy_port %>
     "proxy_port": "<%= @proxy_port %>",
-    <% end %>
-    <%- if @proxy_username %>
     "proxy_username": "<%= @proxy_username %>",
-    <% end %>
-    <%- if @proxy_password %>
     "proxy_password": "<%= @proxy_password %>"
-    <% end %>
 }


### PR DESCRIPTION
If only host or port were specified, a trailing coma resulted in the
configs causing Pulp to fail to start since the JSON was considered
invalid.
