### PR TITLE
Refs #7077/BZ1127242: generate random password for pulp user.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,7 +39,7 @@
 #
 # $default_login::              Initial login; defaults to admin
 #
-# $default_password::           Initial password; defaults to admin
+# $default_password::           Initial password; defaults to 32 character randomly generated password
 #
 # $repo_auth::                  Boolean to determine whether repos managed by
 #                               pulp will require authentication. Defaults

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,7 @@ class pulp::params {
   $qpid_ssl_cert_password_file = undef
 
   $default_login = 'admin'
-  $default_password = 'admin'
+  $default_password = cache_data('pulp_password', random_password(32))
 
   $repo_auth = true
 


### PR DESCRIPTION
Generate a random password instead of using the password "admin"
for the default pulp user.

http://projects.theforeman.org/issues/7077
https://bugzilla.redhat.com/show_bug.cgi?id=1127242
