### PR TITLE
fixes #7296, BZ1135127 - switching to relying on apache for cert validat...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,4 @@ else
 end
 
 gem 'puppet',  puppetversion
-gem 'puppet-lint', '>=0.3.2'
+gem 'puppet-lint', '~> 0.3.2'

--- a/templates/etc/httpd/conf.d/pulp_rpm.conf.erb
+++ b/templates/etc/httpd/conf.d/pulp_rpm.conf.erb
@@ -30,7 +30,7 @@ Alias /pulp/exports /var/www/pub/yum/https/exports
     WSGIAccessScript /srv/pulp/repo_auth.wsgi
 
     SSLRequireSSL
-    SSLVerifyClient optional_no_ca
+    SSLVerifyClient require
     SSLVerifyDepth 2
     SSLOptions +StdEnvVars +ExportCertData +FakeBasicAuth
     Options FollowSymLinks Indexes
@@ -49,7 +49,7 @@ Alias /pulp/isos /var/www/pub/https/isos
     WSGIAccessScript /srv/pulp/repo_auth.wsgi
 
     SSLRequireSSL
-    SSLVerifyClient optional_no_ca
+    SSLVerifyClient require
     SSLVerifyDepth 2
     SSLOptions +StdEnvVars +ExportCertData +FakeBasicAuth
     Options FollowSymLinks Indexes


### PR DESCRIPTION
This moves to using apache to validate the CA instead of some Python code within Pulp
