### PR TITLE
Fixes #8266: Allow setting the number of Pulp workers to be used.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ rvm:
   - 2.1.0
 script: bundle exec rake test
 env:
-  - PUPPET_VERSION="~> 2.7.0"
   - PUPPET_VERSION="~> 3.2.0"
   - PUPPET_VERSION="~> 3.3.0"
   - PUPPET_VERSION="~> 3.4.0"
@@ -17,8 +16,6 @@ env:
   - PUPPET_VERSION="~> 3.6.0"
 matrix:
   exclude:
-  - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 2.7.0"
   - rvm: 2.0.0
     env: PUPPET_VERSION="~> 2.7.0"
   - rvm: 2.1.0

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -107,6 +107,14 @@ class pulp::config {
     mode    => '0644',
   }
 
+  file { '/etc/default/pulp_workers':
+    ensure  => file,
+    content => template("pulp/${pulp::pulp_workers_template}"),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+  }
+
   if $pulp::reset_cache {
     exec {'reset_pulp_cache':
       command => 'rm -rf /var/lib/pulp/packages/*',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,6 +67,9 @@
 #
 # $proxy_password::             Proxy password for authentication
 #
+# $num_workers::                Number of Pulp workers to use
+#                               defaults to number of processors and maxs at 8
+#
 class pulp (
 
   $oauth_key = $pulp::params::oauth_key,
@@ -101,7 +104,9 @@ class pulp (
   $proxy_url      = $pulp::params::proxy_url,
   $proxy_port     = $pulp::params::proxy_port,
   $proxy_username = $pulp::params::proxy_username,
-  $proxy_password = $pulp::params::proxy_password
+  $proxy_password = $pulp::params::proxy_password,
+
+  $num_workers = $pulp::params::num_workers,
 
   ) inherits pulp::params {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,4 +32,28 @@ class pulp::params {
   $proxy_port     = undef
   $proxy_username = undef
   $proxy_password = undef
+
+  $num_workers = min($::processorcount, 8)
+
+  $osreleasemajor = regsubst($::operatingsystemrelease, '^(\d+)\..*$', '\1')
+
+  case $::operatingsystem {
+    'RedHat': {
+      case $osreleasemajor {
+        '6': {
+          $pulp_workers_template = 'upstart_pulp_workers'
+        }
+        default: {
+          $pulp_workers_template = 'systemd_pulp_workers'
+        }
+      }
+    }
+    'Fedora': {
+      $pulp_workers_template = 'systemd_pulp_workers'
+    }
+    default: {
+      fail("${::hostname}: This module does not support osfamily ${::operatingsystem}")
+    }
+  }
+
 }

--- a/spec/classes/pulp_config_spec.rb
+++ b/spec/classes/pulp_config_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+
+describe 'pulp::config' do
+  let :default_facts do
+    {
+      :concat_basedir => '/tmp',
+      :interfaces     => '',
+      :operatingsystem            => 'RedHat',
+      :operatingsystemrelease     => '6.4',
+      :operatingsystemmajrelease  => '6.4',
+      :osfamily                   => 'RedHat',
+      :processorcount             => 3
+    }
+  end
+
+  context 'with no parameters' do
+    let :pre_condition do
+      "class {'pulp':}"
+    end
+
+    let :facts do
+      default_facts
+    end
+
+    it "should configure pulp_workers" do
+      should contain_file('/etc/default/pulp_workers').with({
+        'ensure'  => 'file',
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+      })
+    end
+
+    describe 'with processor count less than 8' do
+
+      it "should set the PULP_CONCURRENCY to the processor count" do
+        should contain_file('/etc/default/pulp_workers').with_content(/^PULP_CONCURRENCY=3$/)
+      end
+
+    end
+
+    describe 'with processor count more than 8' do
+      let :facts do
+        default_facts.merge({
+          :processorcount => 12
+        })
+      end
+
+      it "should set the PULP_CONCURRENCY to 8" do
+        should contain_file('/etc/default/pulp_workers').with_content(/^PULP_CONCURRENCY=8$/)
+      end
+    end
+  end
+
+end

--- a/spec/classes/pulp_spec.rb
+++ b/spec/classes/pulp_spec.rb
@@ -5,11 +5,13 @@ describe 'pulp' do
  context 'on redhat' do
     let :facts do
       {
-        :concat_basedir             => '/tmp',
-        :operatingsystem            => 'RedHat',
-        :operatingsystemrelease     => '6.4',
-        :operatingsystemmajrelease  => '6.4',
-        :osfamily                   => 'RedHat',
+        :concat_basedir            => '/tmp',
+        :operatingsystem           => 'RedHat',
+        :operatingsystemrelease    => '6.4',
+        :operatingsystemmajrelease => '6.4',
+        :osreleasemajor            => '6',
+        :osfamily                  => 'RedHat',
+        :processorcount            => 3,
       }
     end
 

--- a/templates/systemd_pulp_workers
+++ b/templates/systemd_pulp_workers
@@ -1,0 +1,8 @@
+# Configuration file for Pulp's Celery workers
+
+# Define the number of worker nodes you wish to have here. This defaults to the number of processors
+# that are detected on the system if left commented here.
+PULP_CONCURRENCY=<%= scope['pulp::num_workers'] %>
+
+# Configure Python's encoding for writing all logs, stdout and stderr
+PYTHONIOENCODING="UTF-8"

--- a/templates/upstart_pulp_workers
+++ b/templates/upstart_pulp_workers
@@ -1,0 +1,36 @@
+# Configuration file for Pulp's Celery workers
+
+# This template defines where each Celery worker's log will be written. %n is filled in with the
+# name of the worker.
+CELERYD_LOG_FILE="/var/log/pulp/%n.log"
+
+# Configure the log level for the Celery workers here. DEBUG, INFO, WARNING, ERROR, CRITICAL, and
+# FATAL are the allowed values.
+CELERYD_LOG_LEVEL="INFO"
+
+# This template defines where each Celery worker will store its process ID. %n is filled in with the
+# name of the worker.
+CELERYD_PID_FILE="/var/run/pulp/%n.pid"
+
+# Define the number of worker nodes you wish to have here. This defaults to the number of processors
+# that are detected on the system.
+PULP_CONCURRENCY=<%= scope['pulp::num_workers'] %>
+
+# Configure Python's encoding for writing all logs, stdout and stderr
+PYTHONIOENCODING="UTF-8"
+
+######################################################################
+# Please do not edit any of the settings below this mark in this file!
+######################################################################
+CELERY_APP="pulp.server.async.app"
+
+CELERY_CREATE_DIRS=1
+
+CELERYD_NODES=""
+
+# Set the concurrency of each worker node to 1. DO NOT CHANGE THE CONCURRENCY!
+CELERYD_OPTS="-c 1 --events --umask=18"
+
+CELERYD_USER="apache"
+
+DEFAULT_NODES=""


### PR DESCRIPTION
This also adds logic to set the Pulp workers based on processor count
but to cap the maximum at 8 unless overriden by a user.