### PR TITLE
Fixes #8478 - set the version of mongodb we are using

### DIFF
--- a/lib/facter/facts.rb
+++ b/lib/facter/facts.rb
@@ -1,0 +1,16 @@
+Facter.add(:mongodb_version) do
+  setcode do
+    commands = ["rpmquery --qf='%{version}-%{release}' mongodb",
+                "repoquery --qf='%{version}-%{release}' mongodb",
+                %[LC_ALL=en_US yum info mongodb | awk '/^Version/ { version=$3; } /^Release/ { print version "-" $3; exit }']]
+    ret = nil
+    commands.each do |command|
+      version = `#{command} 2>&1`.chomp
+      if $?.success? && !version.empty?
+        ret = version
+        break
+      end
+    end
+    ret
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -103,10 +103,20 @@ class pulp (
 
   include ::apache
 
+  if (versioncmp($::mongodb_version, '2.6.5') >= 0) {
+    $mongodb_pidfilepath = '/var/run/mongodb/mongod.pid'
+  } else {
+    $mongodb_pidfilepath = '/var/run/mongodb/mongodb.pid'
+  }
+
+  class { 'mongodb::globals':
+    version => $::mongodb_version, # taken from the custom facts
+  }
   class { 'apache::mod::wsgi':} ~>
   class { 'mongodb':
-    logpath => '/var/lib/mongodb/mongodb.log',
-    dbpath  => '/var/lib/mongodb',
+    logpath     => '/var/lib/mongodb/mongodb.log',
+    dbpath      => '/var/lib/mongodb',
+    pidfilepath => $mongodb_pidfilepath,
   } ~>
   class { 'qpid':
     ssl                    => true,


### PR DESCRIPTION
The new version puppet-mongodb module expects the version of mongo to be
passed explicitly thought the globals. Load the available version via a custom
fact, as the version might differ on different platforms.
