### PR TITLE
change mongodb logpath

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -114,7 +114,7 @@ class pulp (
   }
   class { 'apache::mod::wsgi':} ~>
   class { 'mongodb':
-    logpath     => '/var/lib/mongodb/mongodb.log',
+    logpath     => '/var/log/mongodb/mongodb.log',
     dbpath      => '/var/lib/mongodb',
     pidfilepath => $mongodb_pidfilepath,
   } ~>


### PR DESCRIPTION
Change mongodb logpath from /var/lib/mongodb/mongodb.log to
/var/log/mongodb/mongodb.log.  Current results in a duplicate resource
error because the mongodb module attempts to create the logdir parent
which is the same as the dbpath.