### PR TITLE
fixes #9204 - fix failing tests due to qpid module's validations

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,6 +50,9 @@
 #
 # $reset_cache::                Boolean to flush the cache. Defaults to false
 #
+# $qpid_ssl::                   Enable SSL in qpid or not
+#                               type:boolean
+#
 # $qpid_ssl_cert_db             The location of the Qpid SSL cert database
 #
 # $qpid_ssl_cert_password_file  Location of the password file for the Qpid SSL cert
@@ -91,6 +94,7 @@ class pulp (
   $reset_data = false,
   $reset_cache = false,
 
+  $qpid_ssl = $pulp::params::qpid_ssl,
   $qpid_ssl_cert_db = $pulp::params::qpid_ssl_cert_db,
   $qpid_ssl_cert_password_file = $pulp::params::qpid_ssl_cert_password_file,
 
@@ -119,7 +123,7 @@ class pulp (
     pidfilepath => $mongodb_pidfilepath,
   } ~>
   class { 'qpid':
-    ssl                    => true,
+    ssl                    => $qpid_ssl,
     ssl_cert_db            => $qpid_ssl_cert_db,
     ssl_cert_password_file => $qpid_ssl_cert_password_file,
     ssl_cert_name          => 'broker',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,8 +17,9 @@ class pulp::params {
 
   $consumers_crl = undef
 
-  $qpid_ssl_cert_db = undef
-  $qpid_ssl_cert_password_file = undef
+  $qpid_ssl = true
+  $qpid_ssl_cert_db = '/etc/pki/example/nssdb'
+  $qpid_ssl_cert_password_file = '/etc/pki/example/nssdb/nss_db_password-file'
 
   $default_login = 'admin'
   $default_password = cache_data('pulp_password', random_password(32))


### PR DESCRIPTION
You can't by default send puppet-qpid `:ssl => true` and no certificates.  I would probably prefer to change ssl default to false, but that's an API change in the module.  Instead I set dummy paths which is probably the only option at the moment. 

When we deal with http://projects.theforeman.org/issues/9207 on this module, we can make the incompatible API change, bump the version, etc.