### PR TITLE
use preffix enable_ for extra packages

### DIFF
--- a/manifests/admin.pp
+++ b/manifests/admin.pp
@@ -54,19 +54,19 @@
 # $wrap_width::                    The number of characters written before wrapping to the next line.
 #                                  type:integer
 #
-# $puppet::                        Install puppet extension
+# $enable_puppet::                 Install puppet extension
 #                                  type:boolean
 #
-# $docker::                        Install puppet extension
+# $enable_docker::                 Install puppet extension
 #                                  type:boolean
 #
-# $nodes::                         Install puppet extension
+# $enable_nodes::                  Install puppet extension
 #                                  type:boolean
 #
-# $python::                        Install puppet extension
+# $enable_python::                 Install puppet extension
 #                                  type:boolean
 #
-# $rpm::                           Install puppet extension
+# $enable_rpm::                    Install puppet extension
 #                                  type:boolean
 #
 # $puppet_upload_working_dir::     Directory where status files for in progress uploads will be stored
@@ -93,14 +93,24 @@ class pulp::admin (
   $enable_color       = $pulp::admin::params::enable_color,
   $wrap_to_terminal   = $pulp::admin::params::wrap_to_terminal,
   $wrap_width         = $pulp::admin::params::wrap_width,
-  $puppet             = $pulp::admin::params::puppet,
-  $docker             = $pulp::admin::params::docker,
-  $nodes              = $pulp::admin::params::nodes,
-  $python             = $pulp::admin::params::python,
-  $rpm                = $pulp::admin::params::rpm,
+  $enable_puppet      = $pulp::admin::params::enable_puppet,
+  $enable_docker      = $pulp::admin::params::enable_docker,
+  $enable_nodes       = $pulp::admin::params::enable_nodes,
+  $enable_python      = $pulp::admin::params::enable_python,
+  $enable_rpm         = $pulp::admin::params::enable_rpm,
   $puppet_upload_working_dir = $pulp::admin::params::puppet_upload_working_dir,
   $puppet_upload_chunk_size  = $pulp::admin::params::puppet_upload_chunk_size,
 ) inherits pulp::admin::params {
+  validate_bool($enable_puppet)
+  validate_bool($enable_docker)
+  validate_bool($enable_nodes)
+  validate_bool($enable_python)
+  validate_bool($enable_rpm)
+
+  validate_bool($verify_ssl)
+  validate_bool($enable_color)
+  validate_bool($wrap_to_terminal)
+
   class { 'pulp::admin::install': } ~>
   class { 'pulp::admin::config': }
 }

--- a/manifests/admin/config.pp
+++ b/manifests/admin/config.pp
@@ -3,12 +3,18 @@ class pulp::admin::config {
   file { '/etc/pulp/admin/admin.conf':
     ensure  => 'file',
     content => template('pulp/admin.conf.erb'),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
   }
 
-  if $pulp::admin::puppet {
+  if $pulp::admin::enable_puppet {
     file { '/etc/pulp/admin/conf.d/puppet.conf':
       ensure  => 'file',
       content => template('pulp/admin_puppet.conf.erb'),
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
     }
   }
 }

--- a/manifests/admin/install.pp
+++ b/manifests/admin/install.pp
@@ -4,31 +4,32 @@ class pulp::admin::install {
     ensure => $pulp::admin::version,
   }
 
-  if $pulp::admin::puppet {
-    package { 'pulp-puppet-admin-extensions':
+  if $pulp::admin::enable_puppet {
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1105673
+    package { ['pulp-puppet-admin-extensions', 'pulp-puppet-tools', 'python-pulp-puppet-common']:
       ensure => $pulp::admin::version,
     }
   }
 
-  if $pulp::admin::docker {
+  if $pulp::admin::enable_docker {
     package { 'pulp-docker-admin-extensions':
       ensure => $pulp::admin::version,
     }
   }
 
-  if $pulp::admin::nodes {
+  if $pulp::admin::enable_nodes {
     package { 'pulp-nodes-admin-extensions':
       ensure => $pulp::admin::version,
     }
   }
 
-  if $pulp::admin::python {
+  if $pulp::admin::enable_python {
     package { 'pulp-python-admin-extensions':
       ensure => $pulp::admin::version,
     }
   }
 
-  if $pulp::admin::rpm {
+  if $pulp::admin::enable_rpm {
     package { 'pulp-rpm-admin-extensions':
       ensure => $pulp::admin::version,
     }

--- a/manifests/admin/params.pp
+++ b/manifests/admin/params.pp
@@ -1,7 +1,7 @@
 # Pulp Admin Params
 class pulp::admin::params {
   $version            = 'installed'
-  $host               = 'localhost'
+  $host               = $::fqdn
   $port               = 443
   $api_prefix         = '/pulp/api'
   $verify_ssl         = true
@@ -18,11 +18,11 @@ class pulp::admin::params {
   $enable_color       = true
   $wrap_to_terminal   = false
   $wrap_width         = 80
-  $puppet             = false
-  $docker             = false
-  $nodes              = false
-  $python             = false
-  $rpm                = false
+  $enable_puppet      = false
+  $enable_docker      = false
+  $enable_nodes       = false
+  $enable_python      = false
+  $enable_rpm         = true
 
   $puppet_upload_working_dir = '~/.pulp/puppet-uploads'
   $puppet_upload_chunk_size  = 1048576

--- a/spec/classes/pulp_admin_spec.rb
+++ b/spec/classes/pulp_admin_spec.rb
@@ -3,6 +3,11 @@ require 'spec_helper'
 describe 'pulp::admin' do
   context 'on RedHat' do
     context 'install class without parameters' do
+      let :facts do
+      {
+        :fqdn => 'localhost',
+      } end
+
       it { should contain_class('pulp::admin::install') }
       it { should contain_class('pulp::admin::config') }
       it { should contain_class('pulp::admin::params') }
@@ -39,7 +44,7 @@ describe 'pulp::admin' do
 
     context 'install with puppet param' do
       let(:params) do {
-          'puppet' => true,
+          'enable_puppet' => true,
         } end
 
       it { should contain_package('pulp-puppet-admin-extensions').with_ensure('installed') }
@@ -56,15 +61,15 @@ describe 'pulp::admin' do
 
     context 'install with docker param' do
       let(:params) do {
-          'docker' => true,
+          'enable_docker' => true,
         } end
 
       it { should contain_package('pulp-docker-admin-extensions').with_ensure('installed') }
     end
 
-    context 'install with puppet nodes' do
+    context 'install with nodes param' do
       let(:params) do {
-          'nodes' => true,
+          'enable_nodes' => true,
         } end
 
       it { should contain_package('pulp-nodes-admin-extensions').with_ensure('installed') }
@@ -72,7 +77,7 @@ describe 'pulp::admin' do
 
     context 'install with python param' do
       let(:params) do {
-          'python' => true,
+          'enable_python' => true,
         } end
 
       it { should contain_package('pulp-python-admin-extensions').with_ensure('installed') }
@@ -80,7 +85,7 @@ describe 'pulp::admin' do
 
     context 'install with rpm param' do
       let(:params) do {
-          'rpm' => true,
+          'enable_rpm' => true,
         } end
 
       it { should contain_package('pulp-rpm-admin-extensions').with_ensure('installed') }

--- a/templates/admin.conf.erb
+++ b/templates/admin.conf.erb
@@ -20,12 +20,12 @@
 #   CA certificates (with openssl-style hashed symlinks, one certificate per file).
 
 [server]
-host: <%= scope.lookupvar('pulp::admin::host') %>
-port: <%= scope.lookupvar('pulp::admin::port') %>
-api_prefix: <%= scope.lookupvar('pulp::admin::api_prefix') %>
-verify_ssl: <%= scope.lookupvar('pulp::admin::verify_ssl') %>
-ca_path: <%= scope.lookupvar('pulp::admin::ca_path') %>
-upload_chunk_size: <%= scope.lookupvar('pulp::admin::upload_chunk_size') %>
+host: <%= scope['pulp::admin::host'] %>
+port: <%= scope['pulp::admin::port'] %>
+api_prefix: <%= scope['pulp::admin::api_prefix'] %>
+verify_ssl: <%= scope['pulp::admin::verify_ssl'] %>
+ca_path: <%= scope['pulp::admin::ca_path'] %>
+upload_chunk_size: <%= scope['pulp::admin::upload_chunk_size'] %>
 
 
 # Client settings.
@@ -33,7 +33,7 @@ upload_chunk_size: <%= scope.lookupvar('pulp::admin::upload_chunk_size') %>
 # role: The client role.
 
 [client]
-role: <%= scope.lookupvar('pulp::admin::role') %>
+role: <%= scope['pulp::admin::role'] %>
 
 
 # The location of resources on the file system.
@@ -49,10 +49,10 @@ role: <%= scope.lookupvar('pulp::admin::role') %>
 #   Directory where status files for in progress uploads will be stored
 
 [filesystem]
-extensions_dir: <%= scope.lookupvar('pulp::admin::extensions_dir') %>
-id_cert_dir: <%= scope.lookupvar('pulp::admin::id_cert_dir') %>
-id_cert_filename: <%= scope.lookupvar('pulp::admin::id_cert_filename') %>
-upload_working_dir: <%= scope.lookupvar('pulp::admin::upload_working_dir') %>
+extensions_dir: <%= scope['pulp::admin::extensions_dir'] %>
+id_cert_dir: <%= scope['pulp::admin::id_cert_dir'] %>
+id_cert_filename: <%= scope['pulp::admin::id_cert_filename'] %>
+upload_working_dir: <%= scope['pulp::admin::upload_working_dir'] %>
 
 
 # Client logging.
@@ -63,8 +63,8 @@ upload_working_dir: <%= scope.lookupvar('pulp::admin::upload_working_dir') %>
 #   If present, the raw REST responses will be logged to the given file.
 
 [logging]
-filename: <%= scope.lookupvar('pulp::admin::log_filename') %>
-call_log_filename: <%= scope.lookupvar('pulp::admin::call_log_filename') %>
+filename: <%= scope['pulp::admin::log_filename'] %>
+call_log_filename: <%= scope['pulp::admin::call_log_filename'] %>
 
 
 # Admin client output.
@@ -81,7 +81,7 @@ call_log_filename: <%= scope.lookupvar('pulp::admin::call_log_filename') %>
 #   The number of characters written before wrapping to the next line.
 
 [output]
-poll_frequency_in_seconds: <%= scope.lookupvar('pulp::admin::poll_frequency_in_seconds') %>
-enable_color: <%= scope.lookupvar('pulp::admin::enable_color') %>
-wrap_to_terminal: <%= scope.lookupvar('pulp::admin::wrap_to_terminal') %>
-wrap_width: <%= scope.lookupvar('pulp::admin::wrap_width') %>
+poll_frequency_in_seconds: <%= scope['pulp::admin::poll_frequency_in_seconds'] %>
+enable_color: <%= scope['pulp::admin::enable_color'] %>
+wrap_to_terminal: <%= scope['pulp::admin::wrap_to_terminal'] %>
+wrap_width: <%= scope['pulp::admin::wrap_width'] %>

--- a/templates/admin_puppet.conf.erb
+++ b/templates/admin_puppet.conf.erb
@@ -1,7 +1,7 @@
 [puppet]
 
 # Directory where status files for in progress uploads will be stored
-upload_working_dir = <%= scope.lookupvar('pulp::admin::puppet_upload_working_dir') %>
+upload_working_dir = <%= scope['pulp::admin::puppet_upload_working_dir'] %>
 
 # Maximum amount of data (in bytes) sent for an upload in a single request
-upload_chunk_size = <%= scope.lookupvar('pulp::admin::puppet_upload_chunk_size') %>
+upload_chunk_size = <%= scope['pulp::admin::puppet_upload_chunk_size'] %>


### PR DESCRIPTION
- also $host = 'localhost' is always wrong, so use $::fqdn instead
- enable default rpm plugin