### PR TITLE
Qpid+ssl with puppet certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,6 @@ If your most recent release breaks compatibility or requires particular steps fo
       }
     
       class { 'pulp':
-        default_password      => 'admin',
-        version               => 'latest',
-        ssl_verify_client     => 'optional_no_ca',
-        enable_puppet         => true,
         messaging_url         => "ssl://${::fqdn}:5671",
         messaging_ca_cert     => $ca_cert,
         messaging_client_cert => $cert,
@@ -105,16 +101,7 @@ If your most recent release breaks compatibility or requires particular steps fo
         broker_use_ssl        => true,
       }
     
-      class { 'pulp::admin':
-        verify_ssl    => false,
-        version       => 'latest',
-        enable_puppet => true,
-      }
-    
       class { 'pulp::consumer':
-        verify_ssl           => false,
-        version              => 'latest',
-        enable_puppet        => true,
         messaging_scheme     => 'ssl',
         messaging_host       => $::fqdn,
         messaging_port       => 5671,

--- a/README.md
+++ b/README.md
@@ -28,11 +28,94 @@ If your most recent release breaks compatibility or requires particular steps fo
 
 ##Usage
 
+###Qpid and ssl using puppet certificates
+
+      $ca_cert = '/etc/pki/pulp/qpid/ca.pem'
+      $cert = '/etc/pki/pulp/qpid/client.pem'
+    
+      file { $ca_cert:
+        source => "${::settings::ssldir}/certs/ca.pem",
+        owner  => 'root',
+        group  => 'apache',
+        mode   => '0640',
+      } ~> Class['pulp::service']
+    
+      concat { $cert:
+        ensure => present,
+        owner  => 'root',
+        group  => 'apache',
+        mode   => '0640',
+      } ~> Class['pulp::service']
+    
+      concat::fragment { 'public_cert':
+        target => $cert,
+        source => "${::settings::ssldir}/certs/${::clientcert}.pem",
+        order  => '01'
+      }
+    
+      concat::fragment { 'private_cert':
+        target => $cert,
+        source => "${::settings::ssldir}/private_keys/${::clientcert}.pem",
+        order  => '02'
+      }
+    
+      nssdb::create { 'qpidd':
+        owner_id => 'qpidd',
+        group_id => 'qpidd',
+        password => 'test_pass',
+        cacert   => "${::settings::ssldir}/certs/ca.pem",
+        basedir  => '/etc/pki/pulp/qpid/nss',
+      } ->
+      nssdb::add_cert_and_key { 'qpidd':
+        nickname => 'broker',
+        cert     => "${::settings::ssldir}/certs/${::clientcert}.pem",
+        key      => "${::settings::ssldir}/private_keys/${::clientcert}.pem",
+        basedir  => '/etc/pki/pulp/qpid/nss'
+      }
+    
+      class { 'qpid':
+        ssl                    => true,
+        ssl_cert_db            => '/etc/pki/pulp/qpid/nss/qpidd',
+        ssl_cert_password_file => '/etc/pki/pulp/qpid/nss/qpidd/password.conf',
+        ssl_cert_name          => 'broker',
+        user_groups            => [],
+      }
+    
+      class { 'pulp':
+        messaging_url         => "ssl://${::fqdn}:5671",
+        messaging_ca_cert     => $ca_cert,
+        messaging_client_cert => $cert,
+        broker_url            => "qpid://${::fqdn}:5671",
+        broker_use_ssl        => true,
+      }
+    
+      class { 'pulp::consumer':
+        messaging_scheme     => 'ssl',
+        messaging_host       => $::fqdn,
+        messaging_port       => 5671,
+        messaging_cacert     => $ca_cert,
+        messaging_clientcert => $cert,
+      }
+
 ##Reference
 
 ##Limitations
 
-* EL6 (RHEL6 / CentOS 6)
+* EL6,7 (RHEL6,7 / CentOS 6,7)
+
+##Pulp consumer
+
+###Installation:
+
+    include pulp::consumer
+
+###Register consumer:
+The provider doesn't support yet updating notes or description.
+
+    pulp_register{$::fqdn:
+    	user => 'admin',
+    	pass => 'admin'
+    }
 
 ##Development
 


### PR DESCRIPTION
Example of using puppet certificates for qpid+ssl connectivity