### PR TITLE
Fixes #10385: Omit errors from yum info when acquiring version.

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,7 +3,9 @@ fixtures:
     stdlib:        "git://github.com/puppetlabs/puppetlabs-stdlib.git"
     foreman:       "git://github.com/theforeman/puppet-foreman.git"
     apache:        "git://github.com/puppetlabs/puppetlabs-apache.git"
-    concat:        "git://github.com/puppetlabs/puppetlabs-concat"
+    concat:
+      repo:   "git://github.com/puppetlabs/puppetlabs-concat"
+      branch: "1.2.x"
     concat_native: "git://github.com/theforeman/puppet-concat"
     mongodb:       "git://github.com/puppetlabs/puppetlabs-mongodb.git"
     qpid:          "git://github.com/katello/puppet-qpid.git"

--- a/lib/facter/facts.rb
+++ b/lib/facter/facts.rb
@@ -2,7 +2,7 @@ Facter.add(:mongodb_version) do
   setcode do
     commands = ["rpmquery --qf='%{version}-%{release}' mongodb",
                 "repoquery --qf='%{version}-%{release}' mongodb",
-                %[LC_ALL=en_US yum info mongodb | awk '/^Version/ { version=$3; } /^Release/ { print version "-" $3; exit }']]
+                %[LC_ALL=en_US yum -e 0 -d 0 info mongodb | awk '/^Version/ { version=$3; } /^Release/ { print version "-" $3; exit }']]
     ret = nil
     commands.each do |command|
       version = `#{command} 2>&1`.chomp


### PR DESCRIPTION
Newer mongodb module from Puppetlabs correctly handles setting the
pidfile and log paths.