### PR TITLE
Refs #10385: repoquery doesn't omit the errors, so we account for that.

### DIFF
--- a/lib/facter/facts.rb
+++ b/lib/facter/facts.rb
@@ -5,7 +5,7 @@ Facter.add(:mongodb_version) do
                 %[LC_ALL=en_US yum -e 0 -d 0 info mongodb | awk '/^Version/ { version=$3; } /^Release/ { print version "-" $3; exit }']]
     ret = nil
     commands.each do |command|
-      version = `#{command} 2>&1`.chomp
+      version = `#{command}`.chomp
       if $?.success? && !version.empty?
         ret = version
         break


### PR DESCRIPTION
Unlike the yum command, repoquery does not omit the errors that can
creep up. This change splits on newlines and grabs the last string
as that will be the version in all scenarios.