### PR TITLE
Remove qpid and mongodb declaration

### DIFF
--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -1,0 +1,20 @@
+# Set up the broker
+class pulp::broker {
+  if $pulp::manage_broker {
+    if $pulp::messaging_transport == 'qpid' {
+      include ::qpid
+      $broker_service = 'qpidd'
+    } elsif $pulp::messaging_transport == 'rabbitmq' {
+      include ::rabbitmq
+      $broker_service = 'rabbitmq-server'
+    }
+
+    Service[$broker_service] -> Service['pulp_celerybeat']
+    Service[$broker_service] -> Service['pulp_workers']
+    Service[$broker_service] -> Service['pulp_resource_manager']
+  } else {
+    if $pulp::messaging_transport == 'qpid' {
+      package { 'qpid-tools': ensure => installed } -> Class['pulp::service']
+    }
+  }
+}

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -87,23 +87,6 @@ class pulp::config {
     }
   }
 
-  if $pulp::reset_data {
-    exec {'reset_pulp_db':
-      command => 'rm -f /var/lib/pulp/init.flag && service-wait httpd stop && service-wait mongod stop && rm -f /var/lib/mongodb/pulp_database*&& service-wait mongod start && rm -rf /var/lib/pulp/{distributions,published,repos}/*',
-      path    => '/sbin:/usr/sbin:/bin:/usr/bin',
-      before  => Exec['migrate_pulp_db'],
-    }
-  }
-
-  exec {'migrate_pulp_db':
-    command   => 'pulp-manage-db && touch /var/lib/pulp/init.flag',
-    creates   => '/var/lib/pulp/init.flag',
-    path      => '/bin:/usr/bin',
-    logoutput => 'on_failure',
-    user      => 'apache',
-    require   => [Service[mongodb], Service[qpidd], File['/etc/pulp/server.conf']],
-  }
-
   if $pulp::consumers_crl {
     exec { 'setup-crl-symlink':
       command     => "/usr/bin/openssl x509 -in '${pulp::consumers_ca_cert}' -hash -noout | /usr/bin/xargs -I{} /bin/ln -sf '${pulp::consumers_crl}' '/etc/pki/pulp/content/{}.r0'",

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -1,0 +1,31 @@
+# Set up the pulp database
+class pulp::database {
+  if $pulp::manage_db {
+    if (versioncmp($::mongodb_version, '2.6.5') >= 0) {
+      $mongodb_pidfilepath = '/var/run/mongodb/mongod.pid'
+    } else {
+      $mongodb_pidfilepath = '/var/run/mongodb/mongodb.pid'
+    }
+
+    class { '::mongodb::server':
+      pidfilepath => $mongodb_pidfilepath,
+    }
+
+    Service['mongodb'] -> Service['pulp_celerybeat']
+    Service['mongodb'] -> Service['pulp_workers']
+    Service['mongodb'] -> Service['pulp_resource_manager']
+    Service['mongodb'] -> Exec['migrate_pulp_db']
+  }
+
+  exec { 'migrate_pulp_db':
+    command     => 'pulp-manage-db',
+    path        => '/bin:/usr/bin',
+    logoutput   => 'on_failure',
+    user        => 'apache',
+    refreshonly => true,
+    require     => File['/etc/pulp/server.conf'],
+  }
+
+  Class['pulp::install'] ~> Exec['migrate_pulp_db'] ~> Class['pulp::service']
+  Class['pulp::config'] ~> Exec['migrate_pulp_db'] ~> Class['pulp::service']
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,6 +8,7 @@ class pulp::params {
   $mongodb_path = '/var/lib/mongodb'
 
   $messaging_url = 'tcp://localhost:5672'
+  $messaging_transport = 'qpid'
   $messaging_ca_cert = undef
   $messaging_client_cert = undef
 
@@ -30,6 +31,9 @@ class pulp::params {
   $enable_child_node = false
 
   $consumers_crl = undef
+
+  $manage_db = true
+  $manage_broker = true
 
   $qpid_ssl = true
   $qpid_ssl_cert_db = '/etc/pki/example/nssdb'


### PR DESCRIPTION
I moved all db related declarations to a new class. This was done only to cleanup the config class. If it's not ok, I can revert this.

- force run of migrate_pulp_db after packages updates and configs updates
- use includes instead of declaring classes
-  add 3 new parameters: messaging_transport = 'qpid', broker_manage=true, db_manage=true (db and broker can be installed on another machine)

