### PR TITLE
Refs #10385: Don't redirect standard err to standard out for mongodb …

### DIFF
--- a/lib/facter/facts.rb
+++ b/lib/facter/facts.rb
@@ -5,7 +5,7 @@ Facter.add(:mongodb_version) do
                 %[LC_ALL=en_US yum -e 0 -d 0 info mongodb | awk '/^Version/ { version=$3; } /^Release/ { print version "-" $3; exit }']]
     ret = nil
     commands.each do |command|
-      version = `#{command} 2>&1`.chomp
+      version = `#{command}`.chomp
       if $?.success? && !version.empty?
         ret = version
         break


### PR DESCRIPTION
…fact

(cherry picked from commit f90720456a268baee18ec7bea30760bcdb7d4edb)