### PR TITLE
make pulp configurable

### DIFF
--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -12,6 +12,7 @@ class pulp::broker {
     Service[$broker_service] -> Service['pulp_celerybeat']
     Service[$broker_service] -> Service['pulp_workers']
     Service[$broker_service] -> Service['pulp_resource_manager']
+    Service[$broker_service] -> Exec['migrate_pulp_db']
   } else {
     if $pulp::messaging_transport == 'qpid' {
       package { 'qpid-tools': ensure => installed } -> Class['pulp::service']

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,4 +1,5 @@
 # Pulp Master Configuration
+# Private class
 class pulp::config {
   if $pulp::enable_puppet {
     exec {'selinux_pulp_manage_puppet':
@@ -23,6 +24,7 @@ class pulp::config {
     mode    => '0600',
   }
 
+  if $pulp::enable_rpm {
   file {'/etc/pulp/repo_auth.conf':
     ensure  => file,
     content => template('pulp/etc/pulp/repo_auth.conf.erb'),
@@ -30,12 +32,14 @@ class pulp::config {
     group   => 'root',
     mode    => '0644',
   }
+  }
 
   file {'/etc/pki/pulp/content/pulp-global-repo.ca':
       ensure => link,
-      target => $pulp::consumers_ca_cert,
+      target => $pulp::ca_cert,
   }
 
+  if $pulp::enable_docker {
   file {'/etc/pulp/server/plugins.conf.d/docker_importer.json':
     ensure  => file,
     content => template('pulp/docker_importer.json'),
@@ -43,7 +47,9 @@ class pulp::config {
     group   => 'root',
     mode    => '0644',
   }
+  }
 
+  if $pulp::enable_rpm {
   file {'/etc/pulp/server/plugins.conf.d/yum_importer.json':
     ensure  => file,
     content => template('pulp/yum_importer.json'),
@@ -51,7 +57,9 @@ class pulp::config {
     group   => 'root',
     mode    => '0644',
   }
+  }
 
+  if $pulp::enable_puppet {
   file {'/etc/pulp/server/plugins.conf.d/puppet_importer.json':
     ensure  => file,
     content => template('pulp/puppet_importer.json'),
@@ -59,13 +67,16 @@ class pulp::config {
     group   => 'root',
     mode    => '0644',
   }
+  }
 
+  if $pulp::enable_rpm {
   file {'/etc/pulp/server/plugins.conf.d/iso_importer.json':
     ensure  => file,
     content => template('pulp/iso_importer.json'),
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
+  }
   }
 
   file { '/etc/default/pulp_workers':
@@ -89,7 +100,7 @@ class pulp::config {
 
   if $pulp::consumers_crl {
     exec { 'setup-crl-symlink':
-      command     => "/usr/bin/openssl x509 -in '${pulp::consumers_ca_cert}' -hash -noout | /usr/bin/xargs -I{} /bin/ln -sf '${pulp::consumers_crl}' '/etc/pki/pulp/content/{}.r0'",
+      command     => "/usr/bin/openssl x509 -in '${pulp::ca_cert}' -hash -noout | /usr/bin/xargs -I{} /bin/ln -sf '${pulp::consumers_crl}' '/etc/pki/pulp/content/{}.r0'",
       logoutput   => 'on_failure',
       refreshonly => true,
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,39 +3,88 @@
 # Install and configure pulp
 #
 # === Parameters:
+# $version::                    pulp package version, it's passed to ensure parameter of package resource
+#                               can be set to specific version number, 'latest', 'present' etc.
 #
-# $oauth_key::                  The oauth key; defaults to pulp
+# $oauth_key::                  string; key to enable OAuth style authentication
 #
-# $oauth_secret::               The oauth secret; defaults to secret
+# $oauth_secret::               string; shared secret that can be used for OAuth style
+#                               authentication
 #
-# $mongodb_path::               Path where mongodb should be stored
+# $oauth_enabled::              boolean; controls whether OAuth authentication is enabled
 #
-# $messaging_url::              URL for the AMQP server that Pulp will use to
-#                               communicate with nodes.
+# $messaging_url::              the url used to contact the broker: <protocol>://<host>:<port>/<virtual-host>
+#                               Supported <protocol>  values are 'tcp' or 'ssl' depending on if SSL should be used or not.
+#                               The <virtual-host> is optional, and is only applicable to RabbitMQ broker environments.
 #
 # $messaging_transport::        The type of broker you are connecting to. The default is 'qpid'.
 #                               For RabbitMQ, 'rabbitmq' should be used.
 #
-# $messaging_ca_cert:           The CA cert to authenicate against the AMQP server.
+# $messaging_ca_cert::          Absolute path to PEM encoded CA certificate file, used by Pulp to validate the identity
+#                               of the broker using SSL.
 #
-# $messaging_client_cert::      The client certificate signed by the CA cert
-#                               above to authenticate.
+# $messaging_client_cert::      Absolute path to PEM encoded file containing both the private key and
+#                               certificate Pulp should present to the broker to be authenticated by the broker.
 #
-# $broker_url::                 URL for the Celery broker that Pulp will use to
-#                               queue tasks.
+# $broker_url::                 A URL to a broker that Celery can use to queue tasks:
+#                               qpid://<username>:<password>@<hostname>:<port>/
 #
-# $broker_use_ssl::             Set to true if deploying broker for Celery with SSL.
+# $broker_use_ssl::             Require SSL if set to 'true', otherwise do not require SSL.
 #
-# $consumers_ca_cert::          The path to the CA cert that will be used to sign customer
-#                               and admin identification certificates
+# $ca_cert::                    full path to the CA certificate that will be used to sign consumer
+#                               and admin identification certificates; this must match the value of
+#                               SSLCACertificateFile in /etc/httpd/conf.d/pulp.conf
 #
-# $consumers_ca_key::           The private key for the CA cert
+# $ca_key::                     path to the private key for the above CA certificate
+#
+# $db_name::                    name of the database to use
+#
+# $db_seeds::                   comma-separated list of hostname:port of database replica seed hosts
+#
+# $db_username::                The user name to use for authenticating to the MongoDB server
+#
+# $db_password::                The password to use for authenticating to the MongoDB server
+#
+# $db_replica_set::             and set this value to the name of replica set configured in MongoDB,
+#                               if one is in use
+#
+# $db_ssl::                     If True, create the connection to the server using SSL.
+#
+# $db_ssl_keyfile::             A path to the private keyfile used to identify the local connection against
+#                               mongod. If included with the certfile then only the ssl_certfile is needed.
+#
+# $db_ssl_certfile::            The certificate file used to identify the local connection against mongod.
+#
+# $db_verify_ssl::              Specifies whether a certificate is required from the other side of the
+#                               connection, and whether it will be validated if provided. If it is true, then
+#                               the ssl_ca_certs parameter must point to a file of CA certificates used to
+#                               validate the connection.
+#
+# $db_ca_path::                 The ca_certs file contains a set of concatenated “certification authority”
+#                               certificates, which are used to validate certificates passed from the other end
+#                               of the connection.
+#
+# $server_name::                hostname the admin client and consumers should use when accessing
+#                               the server; if not specified, this is defaulted to the server's hostname
+#
+# $key_url::
+#
+# $ks_url::
+#
+# $debugging_mode::             boolean; toggles Pulp's debugging capabilities
+#
+# $log_level::                  The desired logging level. Options are: CRITICAL, ERROR, WARNING, INFO, DEBUG,
+#                               and NOTSET. Pulp will default to INFO.
+#
+# $rsa_key::                    The RSA private key used for authentication.
+#
+# $rsa_pub::                    The RSA public key used for authentication.
 #
 # $https_cert::                 apache public certificate for ssl
 #
 # $https_key::                  apache private certificate for ssl
 #
-# $ssl_ca_cert::                Full path to the CA certificate used to sign the Pulp
+# $ssl_ca_cert::                full path to the CA certificate used to sign the Pulp
 #                               server's SSL certificate; consumers will use this to verify the
 #                               Pulp server's SSL certificate during the SSL handshake
 #
@@ -43,33 +92,54 @@
 #                               are no valid (have had their client certs
 #                               revoked)
 #
-# $ssl_ca_cert::                The SSL cert that will be used by Pulp to
-#                               verify the connection
+# $user_cert_expiration::       number of days a user certificate is valid
 #
-# $default_login::              Initial login; defaults to admin
+# $default_login::              default admin username of the Pulp server; this user will be
+#                               the first time the server is started
 #
-# $default_password::           Initial password; defaults to 32 character randomly generated password
+# $default_password::           default password for admin when it is first created; this
+#                               should be changed once the server is operational
 #
 # $repo_auth::                  Boolean to determine whether repos managed by
 #                               pulp will require authentication. Defaults
 #                               to true
+#                               type:boolean
+#
+# $consumer_cert_expiration::   number of days a consumer certificate is valid
 #
 # $reset_cache::                Boolean to flush the cache. Defaults to false
+#                               type:boolean
 #
 # $ssl_verify_client::          Enforce use of SSL authentication for yum repos access
 #
-# $qpid_ssl::                   Enable SSL in qpid or not
+# $serial_number_path::
+#
+# $consumer_history_lifetime::  number of days to store consumer events; events older
+#                               than this will be purged; set to -1 to disable
+#
+# $messaging_url::              the url used to contact the broker: <protocol>://<host>:<port>/<virtual-host>
+#                               Supported <protocol>  values are 'tcp' or 'ssl' depending on if SSL should be used or not.
+#                               The <virtual-host> is optional, and is only applicable to RabbitMQ broker environments.
+#
+# $messaging_auth_enabled::     Message authentication enabled flag. The default is 'true' which enables authentication.
+#                               To disable authentication, use 'false'.
+#
+# $messaging_topic_exchange::   The name of the exchange to use. The exchange must be a topic exchange. The
+#                               default is 'amq.topic', which is a default exchange that is guaranteed to exist on a Qpid broker.
+#
+# $email_host::                 host name of the MTA pulp should relay through
+#
+# $email_port::                 destination port to connect on
+#
+# $email_from::                 the "From" address of each email the system sends
+#
+# $email_enabled::              boolean controls whether or not emails will be sent
 #                               type:boolean
-#
-# $qpid_ssl_cert_db             The location of the Qpid SSL cert database
-#
-# $qpid_ssl_cert_password_file  Location of the password file for the Qpid SSL cert
-#
-# $user_groups::                Additional user groups to add the qpid user to
 #
 # $proxy_url::                  URL of the proxy server
 #
 # $proxy_port::                 Port the proxy is running on
+#                               type:integer
 #
 # $proxy_username::             Proxy username for authentication
 #
@@ -77,6 +147,7 @@
 #
 # $num_workers::                Number of Pulp workers to use
 #                               defaults to number of processors and maxs at 8
+#                               type:integer
 #
 # $enable_rpm::                 Boolean to enable rpm plugin. Defaults
 #                               to true
@@ -106,73 +177,103 @@
 #                               to false
 #                               type:boolean
 #
+#
 # $manage_httpd::               Boolean to install and configure the httpd server. Defaults
 #                               to true
 #                               type:boolean
 #
-# $manage_broker::             Boolean to install and configure the qpid or rabbitmq broker.
-#                               Defaults to false
+# $manage_broker::              Boolean to install and configure the qpid or rabbitmq broker.
+#                               Defaults to true
 #                               type:boolean
 #
-# $manage_db::                 Boolean to install and configure the mongodb. Defaults
-#                               to false
+# $manage_db::                  Boolean to install and configure the mongodb. Defaults
+#                               to true
 #                               type:boolean
+#
+# $node_certificate::           The absolute path to the node SSL certificate
+#
+# $node_verify_ssl::
+#
+# $node_server_ca_cert::
+#
+# $node_oauth_effective_user::
+#
+# $node_oauth_key::             The oauth key used to authenticate to the parent node
+#
+# $node_oauth_secret::          The oauth secret used to authenticate to the parent node
 #
 class pulp (
-
-  $oauth_key = $pulp::params::oauth_key,
-  $oauth_secret = $pulp::params::oauth_secret,
-
-  $mongodb_path = $pulp::params::mongodb_path,
-
-  $messaging_url = $pulp::params::messaging_url,
-  $messaging_transport       = $pulp::params::messaging_transport,
-  $messaging_ca_cert = $pulp::params::messaging_ca_cert,
-  $messaging_client_cert = $pulp::params::messaging_client_cert,
-
-  $broker_url = $pulp::params::broker_url,
-  $broker_use_ssl = $pulp::params::broker_use_ssl,
-
-  $consumers_ca_cert = $pulp::params::consumers_ca_cert,
-  $consumers_ca_key = $pulp::params::consumers_ca_key,
+  $version                   = $pulp::params::version,
+  $db_name                   = $pulp::params::db_name,
+  $db_seeds                  = $pulp::params::db_seeds,
+  $db_username               = $pulp::params::db_username,
+  $db_password               = $pulp::params::db_password,
+  $db_replica_set            = $pulp::params::db_replica_set,
+  $db_ssl                    = $pulp::params::db_ssl,
+  $db_ssl_keyfile            = $pulp::params::db_ssl_keyfile,
+  $db_ssl_certfile           = $pulp::params::db_ssl_certfile,
+  $db_verify_ssl             = $pulp::params::db_verify_ssl,
+  $db_ca_path                = $pulp::params::db_ca_path,
+  $server_name               = $pulp::params::server_name,
+  $key_url                   = $pulp::params::key_url,
+  $ks_url                    = $pulp::params::ks_url,
+  $default_login             = $pulp::params::default_login,
+  $default_password          = $pulp::params::default_password,
+  $debugging_mode            = $pulp::params::debugging_mode,
+  $log_level                 = $pulp::params::log_level,
+  $rsa_key                   = $pulp::params::rsa_key,
+  $rsa_pub                   = $pulp::params::rsa_pub,
+  $ca_cert                   = $pulp::params::ca_cert,
+  $ca_key                    = $pulp::params::ca_key,
   $https_cert                = $pulp::params::https_cert,
   $https_key                 = $pulp::params::https_key,
-  $ssl_ca_cert = $pulp::params::ssl_ca_cert,
-
-  $consumers_crl = $pulp::params::consumers_crl,
-
-  $ssl_ca_cert = $pulp::params::ssl_ca_cert,
-
-  $default_password = $pulp::params::default_password,
-
-  $repo_auth = true,
-
-  $reset_cache = false,
-
+  $ssl_ca_cert               = $pulp::params::ssl_ca_cert,
+  $user_cert_expiration      = $pulp::params::user_cert_expiration,
+  $consumer_cert_expiration  = $pulp::params::consumer_cert_expiration,
+  $serial_number_path        = $pulp::params::serial_number_path,
+  $consumer_history_lifetime = $pulp::params::consumer_history_lifetime,
+  $oauth_enabled             = $pulp::params::oauth_enabled,
+  $oauth_key                 = $pulp::params::oauth_key,
+  $oauth_secret              = $pulp::params::oauth_secret,
+  $messaging_url             = $pulp::params::messaging_url,
+  $messaging_transport       = $pulp::params::messaging_transport,
+  $messaging_auth_enabled    = $pulp::params::messaging_auth_enabled,
+  $messaging_ca_cert         = $pulp::params::messaging_ca_cert,
+  $messaging_client_cert     = $pulp::params::messaging_client_cert,
+  $messaging_topic_exchange  = $pulp::params::messaging_topic_exchange,
+  $broker_url                = $pulp::params::broker_url,
+  $broker_use_ssl            = $pulp::params::broker_use_ssl,
+  $email_host                = $pulp::params::email_host,
+  $email_port                = $pulp::params::email_port,
+  $email_from                = $pulp::params::email_from,
+  $email_enabled             = $pulp::params::email_enabled,
+  $consumers_crl             = $pulp::params::consumers_crl,
+  $reset_cache               = $pulp::params::reset_cache,
   $ssl_verify_client         = $pulp::params::ssl_verify_client,
-  $qpid_ssl = $pulp::params::qpid_ssl,
-  $qpid_ssl_cert_db = $pulp::params::qpid_ssl_cert_db,
-  $qpid_ssl_cert_password_file = $pulp::params::qpid_ssl_cert_password_file,
-
-  $proxy_url      = $pulp::params::proxy_url,
-  $proxy_port     = $pulp::params::proxy_port,
-  $proxy_username = $pulp::params::proxy_username,
-  $proxy_password = $pulp::params::proxy_password,
-
-  $num_workers = $pulp::params::num_workers,
-  $manage_broker             = $pulp::params::manage_broker,
-  $manage_db                 = $pulp::params::manage_db,
-
+  $repo_auth                 = $pulp::params::repo_auth,
+  $proxy_url                 = $pulp::params::proxy_url,
+  $proxy_port                = $pulp::params::proxy_port,
+  $proxy_username            = $pulp::params::proxy_username,
+  $proxy_password            = $pulp::params::proxy_password,
+  $num_workers               = $pulp::params::num_workers,
   $enable_docker             = $pulp::params::enable_docker,
   $enable_rpm                = $pulp::params::enable_rpm,
   $enable_puppet             = $pulp::params::enable_puppet,
   $enable_python             = $pulp::params::enable_python,
   $enable_parent_node        = $pulp::params::enable_parent_node,
-  $enable_child_node         = $pulp::params::enable_child_node,
   $enable_http               = $pulp::params::enable_http,
+  $manage_broker             = $pulp::params::manage_broker,
+  $manage_db                 = $pulp::params::manage_db,
   $manage_httpd              = $pulp::params::manage_httpd,
-
-  ) inherits pulp::params {
+  $node_certificate          = $pulp::params::node_certificate,
+  $node_verify_ssl           = $pulp::params::node_verify_ssl,
+  $node_server_ca_cert       = $pulp::params::node_server_ca_cert,
+  $node_oauth_effective_user = $pulp::params::node_oauth_effective_user,
+  $node_oauth_key            = $pulp::params::node_oauth_key,
+  $node_oauth_secret         = $pulp::params::node_oauth_secret,
+) inherits pulp::params {
+  validate_bool($repo_auth)
+  validate_bool($reset_cache)
   validate_bool($enable_docker)
   validate_bool($enable_rpm)
   validate_bool($enable_puppet)
@@ -180,12 +281,13 @@ class pulp (
   validate_bool($enable_http)
   validate_bool($manage_db)
   validate_bool($manage_broker)
+  validate_bool($manage_httpd)
+  validate_bool($enable_parent_node)
 
-  include ::apache
   include ::mongodb::client
-
-  include ::pulp::broker
+  include ::pulp::apache
   include ::pulp::database
+  include ::pulp::broker
   class { '::pulp::install': } ->
   class { '::pulp::config': } ~>
   class { '::pulp::service': } ~>

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,8 +1,35 @@
 # Pulp Installation Packages
+# Private class
 class pulp::install {
+  package { ['pulp-server', 'pulp-selinux']: ensure => $pulp::version, }
 
-  package{ ['pulp-server', 'pulp-selinux', 'pulp-docker-plugins', 'pulp-rpm-plugins', 'pulp-puppet-plugins', 'pulp-nodes-parent']:
-    ensure => installed,
+  if $pulp::messaging_transport == 'qpid' {
+    ensure_packages(['python-gofer-qpid'], {
+      ensure => $pulp::version
+    }
+    )
   }
 
+  if $pulp::messaging_transport == 'rabbitmq' {
+    ensure_packages(['python-gofer-amqp'], {
+      ensure => $pulp::version
+    }
+    )
+  }
+
+  if $pulp::enable_rpm {
+    package { ['pulp-rpm-plugins']: ensure => $pulp::version, }
+  }
+
+  if $pulp::enable_docker {
+    package { ['pulp-docker-plugins']: ensure => $pulp::version, }
+  }
+
+  if $pulp::enable_puppet {
+    package { ['pulp-puppet-plugins']: ensure => $pulp::version, }
+  }
+
+  if $pulp::enable_python {
+    package { ['pulp-python-plugins']: ensure => $pulp::version, }
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,24 +1,51 @@
 # Pulp Master Params
+# Private class
 class pulp::params {
-  $manage_httpd = true
+  $version = 'installed'
 
+  $db_name = 'pulp_database'
+  $db_seeds = 'localhost:27017'
+  $db_username = undef
+  $db_password = undef
+  $db_replica_set = undef
+  $db_ssl = false
+  $db_ssl_keyfile = undef
+  $db_ssl_certfile = undef
+  $db_verify_ssl = true
+  $db_ca_path = '/etc/pki/tls/certs/ca-bundle.crt'
+
+  $server_name = downcase($::fqdn)
+  $key_url = '/pulp/gpg'
+  $ks_url = '/pulp/ks'
+  $debugging_mode = false
+  $log_level = 'INFO'
+
+  $rsa_key = '/etc/pki/pulp/rsa.key'
+  $rsa_pub = '/etc/pki/pulp/rsa_pub.key'
+
+  $user_cert_expiration = 7
+  $consumer_cert_expiration = 3650
+  $serial_number_path = '/var/lib/pulp/sn.dat'
+
+  $consumer_history_lifetime = 180
+  $oauth_enabled = true
   $oauth_key = 'pulp'
   $oauth_secret = 'secret'
 
-  $mongodb_path = '/var/lib/mongodb'
-
-  $messaging_url = 'tcp://localhost:5672'
+  $messaging_url = "tcp://${::fqdn}:5672"
   $messaging_transport = 'qpid'
+  $messaging_auth_enabled = true
   $messaging_ca_cert = undef
   $messaging_client_cert = undef
+  $messaging_topic_exchange = 'amq.topic'
 
-  $broker_url = "qpid://${::fqdn}:5671"
-  $broker_use_ssl = true
+  $broker_url = "qpid:///guest@${::fqdn}:5672"
+  $broker_use_ssl = false
 
-  $consumers_ca_cert = '/etc/pki/pulp/ca.crt'
-  $consumers_ca_key = '/etc/pki/pulp/ca.key'
-  $https_cert  = $consumers_ca_cert
-  $https_key   = $consumers_ca_key
+  $ca_cert = '/etc/pki/pulp/ca.crt'
+  $ca_key = '/etc/pki/pulp/ca.key'
+  $https_cert = $ca_cert
+  $https_key = $ca_key
   $ssl_ca_cert = '/etc/pki/pulp/ssl_ca.crt'
   $enable_http = false
   $ssl_verify_client = 'require'
@@ -28,30 +55,37 @@ class pulp::params {
   $enable_puppet = false
   $enable_python = false
   $enable_parent_node = false
-  $enable_child_node = false
+
+  $email_host = 'localhost'
+  $email_port = 25
+  $email_from = "no-reply@${::domain}"
+  $email_enabled = false
 
   $consumers_crl = undef
 
   $manage_db = true
   $manage_broker = true
-
-  $qpid_ssl = true
-  $qpid_ssl_cert_db = '/etc/pki/example/nssdb'
-  $qpid_ssl_cert_password_file = '/etc/pki/example/nssdb/nss_db_password-file'
+  $manage_httpd = true
+  $reset_cache = false
 
   $default_login = 'admin'
   $default_password = cache_data('pulp_password', random_password(32))
 
-  $repo_auth = true
+  $repo_auth = false
 
-  $user_groups = []
-
-  $proxy_url      = undef
-  $proxy_port     = undef
+  $proxy_url = undef
+  $proxy_port = undef
   $proxy_username = undef
   $proxy_password = undef
 
   $num_workers = min($::processorcount, 8)
+
+  $node_certificate = '/etc/pki/pulp/nodes/node.crt'
+  $node_verify_ssl = true
+  $node_server_ca_cert = '/etc/pki/pulp/ca.crt'
+  $node_oauth_effective_user = 'admin'
+  $node_oauth_key = 'pulp'
+  $node_oauth_secret = 'secret'
 
   $osreleasemajor = regsubst($::operatingsystemrelease, '^(\d+)\..*$', '\1')
 

--- a/templates/etc/pulp/nodes.conf.erb
+++ b/templates/etc/pulp/nodes.conf.erb
@@ -2,16 +2,15 @@
 # node_certificate - The absolute path to the node SSL certificate
 
 [main]
-node_certificate: /etc/pki/pulp/nodes/node.crt
-verify_ssl: True
-ca_path: <%= @server_ca_cert %>
+node_certificate: <%= scope['pulp::node_certificate'] %>
+verify_ssl: <%= scope['pulp::node_verify_ssl'] %>
+ca_path: <%= scope['pulp::node_server_ca_cert'] %>
 
 # The oauth configuration used to authenticate to this node
 # user_id - The pulp user ID
 
 [oauth]
-user_id: admin
-
+user_id: <%= scope['pulp::node_oauth_effective_user'] %>
 
 # The oauth configuration used to authenticate to the parent node
 # key     - The oauth key
@@ -19,6 +18,6 @@ user_id: admin
 # user_id - The pulp user ID
 
 [parent_oauth]
-key: <%= @oauth_key %>
-secret: <%= @oauth_secret %>
-user_id: <%= @oauth_effective_user %>
+key: <%= scope['pulp::node_oauth_key'] %>
+secret: <%= scope['pulp::node_oauth_secret'] %>
+user_id: <%= scope['pulp::node_oauth_effective_user'] %>

--- a/templates/etc/pulp/repo_auth.conf.erb
+++ b/templates/etc/pulp/repo_auth.conf.erb
@@ -1,7 +1,15 @@
-#
-
 [main]
 enabled: <%= @repo_auth ? "true" : "false" %>
+log_failed_cert: true
+log_failed_cert_verbose: false
+max_num_certs_in_chain: 100
+# If this is true, the client certificate will be verified by Pulp against the per-repo certificate
+# authorities. If it is false, client certificates will not be checked for signature or expiration.
+# If you don't need per-repo CAs, it is recommended to set this to false and use your web server to
+# check the client certificates against a trusted CA back. Setting this to true will have a negative
+# performance impact, so don't do that unless you need per-repo CAs. It is true by default to
+# maintain backwards compatibility.
+verify_ssl: false
 
 [repos]
 cert_location: /etc/pki/pulp/content
@@ -10,4 +18,3 @@ protected_repo_listing_file: /etc/pki/pulp/content/pulp-protected-repos
 
 [crl]
 location: /etc/pki/pulp/content
-

--- a/templates/etc/pulp/server.conf.erb
+++ b/templates/etc/pulp/server.conf.erb
@@ -11,28 +11,50 @@
 #
 # Controls the behavior of MongoDB under Pulp's usage.
 #
-# name: name of the database to use
-# seeds: comma-separated list of hostname:port of database replica seed hosts
-# operation_retries: number of retries on database operations to
-#     perform before giving up and reporting an error
-#
 # Authentication - If the username and the password keys have values provided,
 # the pulp server will attempt to authenticate to the MongoDB server.  The
 # username and password provided here will be used to authenticate with the
 # database specified in the name field.
 #
-# username: The user name to use for authenticating to the MongoDB server
-# password: The password to use for authenticating to the MongoDB server
-# replica_set: uncomment and set this value to the name of replica set configured
-#     in MongoDB, if one is in use
+# name:              name of the database to use
+# seeds:             comma-separated list of hostname:port of database replica seed hosts
+# username:          The user name to use for authenticating to the MongoDB server
+# password:          The password to use for authenticating to the MongoDB server
+# replica_set:       uncomment and set this value to the name of replica set configured in MongoDB,
+#                    if one is in use
+# ssl:               If True, create the connection to the server using SSL.
+# ssl_keyfile:       A path to the private keyfile used to identify the local connection against
+#                    mongod. If included with the certfile then only the ssl_certfile is needed.
+# ssl_certfile:      The certificate file used to identify the local connection against mongod.
+# verify_ssl:        Specifies whether a certificate is required from the other side of the
+#                    connection, and whether it will be validated if provided. If it is true, then
+#                    the ssl_ca_certs parameter must point to a file of CA certificates used to
+#                    validate the connection.
+# ca_path:           The ca_certs file contains a set of concatenated “certification authority”
+#                    certificates, which are used to validate certificates passed from the other end
+#                    of the connection.
 
 [database]
-# name: pulp_database
-# seeds: localhost:27017
-# operation_retries: 2
-# username: admin
-# password: admin
-# replica_set: replica_set_name
+name: <%= scope['pulp::db_name'] %>
+seeds: <%= scope['pulp::db_seeds'] %>
+<% if scope['pulp::db_username'] != :undef -%>
+username: <%= scope['pulp::db_username'] %>
+<% end -%>
+<% if scope['pulp::db_password'] != :undef -%>
+password: <%= scope['pulp::db_password'] %>
+<% end -%>
+<% if scope['pulp::db_replica_set'] != :undef -%>
+replica_set: <%= scope['pulp::db_replica_set'] %>
+<% end -%>
+ssl: <%= scope['pulp::db_ssl'] %>
+<% if scope['pulp::db_ssl'] -%>
+<% if scope['pulp::db_ssl_keyfile'] != :undef -%>
+ssl_keyfile: <%= scope['pulp::db_ssl_keyfile'] %>
+<% end -%>
+ssl_certfile: <%= scope['pulp::db_ssl_certfile'] %>
+verify_ssl: <%= scope['pulp::db_verify_ssl'] %>
+ca_path: <%= scope['pulp::db_ca_path'] %>
+<% end -%>
 
 
 # = Server =
@@ -49,13 +71,13 @@
 # log_level:        The desired logging level. Options are: CRITICAL, ERROR, WARNING, INFO, DEBUG,
 #                   and NOTSET. Pulp will default to INFO.
 [server]
-server_name: <%= (has_variable?("fqdn") ? @fqdn : @hostname).downcase %>
-# key_url: /pulp/gpg
-# ks_url: /pulp/ks
-default_login: <%= @default_login %>
-default_password: <%= @default_password %>
-# debugging_mode: false
-# log_level: INFO
+server_name: <%= scope['pulp::server_name'] %>
+key_url: <%= scope['pulp::key_url'] %>
+ks_url: <%= scope['pulp::ks_url'] %>
+default_login: <%= scope['pulp::default_login'] %>
+default_password: <%= scope['pulp::default_password'] %>
+debugging_mode: <%= scope['pulp::debugging_mode'] %>
+log_level: <%= scope['pulp::log_level'] %>
 
 
 # = Authentication =
@@ -68,8 +90,8 @@ default_password: <%= @default_password %>
 #   The RSA public key used for authentication.
 
 [authentication]
-# rsa_key = /etc/pki/pulp/rsa.key
-# rsa_pub = /etc/pki/pulp/rsa_pub.key
+rsa_key = <%= scope['pulp::rsa_key'] %>
+rsa_pub = <%= scope['pulp::rsa_pub'] %>
 
 
 # = Security =
@@ -96,12 +118,12 @@ default_password: <%= @default_password %>
 #
 
 [security]
-cacert:  <%= @consumers_ca_cert %>
-cakey:   <%= @consumers_ca_key %>
-ssl_ca_certificate: <%= @ssl_ca_cert %>
-# user_cert_expiration: 7
-# consumer_cert_expiration: 3650
-# serial_number_path: /var/lib/pulp/sn.dat
+cacert: <%= scope['pulp::ca_cert'] %>
+cakey: <%= scope['pulp::ca_key'] %>
+ssl_ca_certificate: <%= scope['pulp::ssl_ca_cert'] %>
+user_cert_expiration: <%= scope['pulp::user_cert_expiration'] %>
+consumer_cert_expiration: <%= scope['pulp::consumer_cert_expiration'] %>
+serial_number_path: <%= scope['pulp::serial_number_path'] %>
 
 
 # -- Advanced Configuration ---------------------------------------------------
@@ -114,7 +136,7 @@ ssl_ca_certificate: <%= @ssl_ca_cert %>
 #     than this will be purged; set to -1 to disable
 
 [consumer_history]
-# lifetime: 180
+lifetime: <%= scope['pulp::consumer_history_lifetime'] %>
 
 
 # = Data Reaping =
@@ -137,14 +159,19 @@ ssl_ca_certificate: <%= @ssl_ca_cert %>
 #
 # repo_group_publish_history: float; time in days to store repository group
 #     publish history events
+#
+# task_status_history: float; time in days to store task status history in the db
+# task_result_history: float; time in days to store task results history
 
 [data_reaping]
-# reaper_interval: 0.25
-# archived_calls: 0.5
-# consumer_history: 60
-# repo_sync_history: 60
-# repo_publish_history: 60
-# repo_group_publish_history: 60
+reaper_interval: 0.25
+archived_calls: 0.5
+consumer_history: 60
+repo_sync_history: 60
+repo_publish_history: 60
+repo_group_publish_history: 60
+task_status_history: 7
+task_result_history: 3
 
 
 # = LDAP =
@@ -192,81 +219,100 @@ ssl_ca_certificate: <%= @ssl_ca_cert %>
 #     authentication
 
 [oauth]
-enabled: true
-oauth_key: <%= @oauth_key %>
-oauth_secret: <%= @oauth_secret %>
+enabled: <%= scope['pulp::oauth_enabled'] %>
+oauth_key: <%= scope['pulp::oauth_key'] %>
+oauth_secret: <%= scope['pulp::oauth_secret'] %>
+
 
 # = Messaging =
 #
-# Controls Pulp's configuration of QPID for remote messaging.
+# Controls Pulp's configuration of broker settings for communicating to the Consumer Agent.
 #
-# url: the url used to contact the broker in the form
-#     <transport>://<host>:<port>; transport can be 'tcp' or 'ssl'
+# url: the url used to contact the broker. This setting uses the form:
 #
-# transport: The type of broker you are connecting to. May be "qpid" or "amqplib" (for RabbitMQ).
-#            Defaults to qpid.
+#         <protocol>://<host>:<port>/<virtual-host>
 #
-# cacert: full path to PEM encoded CA certificate file, used when Pulp connects
-#     to a broker over SSL
+#     Or to use a username and password:
 #
-# clientcert: full path to PEM encoded file containing both the private key and
-#     certificate Pulp should present to the broker to be authenticated
+#         <protocol>://<user>:<password>@<host>:<port>/<virtual-host>
+#
+#     Supported <protocol>  values are 'tcp' or 'ssl' depending on if SSL should be used or not.
+#     The <virtual-host> is optional, and is only applicable to RabbitMQ broker environments.
+#
+#     The default broker string is 'tcp://localhost:5672'.
+#
+# transport: The type of broker you are connecting to. The default is 'qpid'. For RabbitMQ,
+#     'rabbitmq' should be used.
+#
+# cacert: Absolute path to PEM encoded CA certificate file, used by Pulp to validate the identity
+#     of the broker using SSL. The default is '/etc/pki/qpid/ca/ca.crt'.
+#
+# clientcert: Absolute path to PEM encoded file containing both the private key and
+#     certificate Pulp should present to the broker to be authenticated by the broker. The default
+#     is '/etc/pki/qpid/client/client.pem'.
 #
 # auth_enabled:
-#     Message authentication enabled flag.
+#     Message authentication enabled flag. The default is 'true' which enables authentication.
+#     To disable authentication, use 'false'.
 #
-# topic_exchange: name of the exchange to use; must be a topic exchange;
-#     defaults to "amq.topic", which is a default exchange that
-#     is guaranteed to exist on the broker
-#
-# The format for the following timeouts is <start>:<duration>. The <start>
-# timeout is the time to wait for the consumer to acknowledge and
-# begin handling the request before indicating a timeout has occurred. The
-# <duration> timeout is how long the consumer is allowed to act on the request
-# before the server considers the entire request timed out.  The default unit is
-# seconds.  The numeric value may be specified with an optional unit suffix.
-# Supported suffixes are: s=seconds, m=minutes, h=hours, d=days.
+# topic_exchange: The name of the exchange to use. The exchange must be a topic exchange. The
+#     default is 'amq.topic', which is a default exchange that is guaranteed to exist on a Qpid
+#     broker. This setting is a string, and therefore includes the single quotes.
 #
 
 [messaging]
-url: <%= @messaging_url %>
-<% if @messaging_ca_cert -%>
-cacert: <%= @messaging_ca_cert %>
+url: <%= scope['pulp::messaging_url'] %>
+transport: <%= scope['pulp::messaging_transport'] %>
+auth_enabled: <%= scope['pulp::messaging_auth_enabled'] %>
+<% if scope['pulp::messaging_ca_cert'] -%>
+cacert: <%= scope['pulp::messaging_ca_cert'] %>
 <% end -%>
-<% if @messaging_client_cert -%>
-clientcert: <%= @messaging_client_cert %>
+<% if scope['pulp::messaging_client_cert'] -%>
+clientcert: <%= scope['pulp::messaging_client_cert'] %>
 <% end -%>
-transport: qpid
-auth_enabled: false
-# topic_exchange: 'amq.topic'
+topic_exchange: '<%= scope['pulp::oauth_enabled'] %>'
 
 
 # = Asynchronous Tasks =
 #
-# Controls Pulp's Celery settings.
+# Controls Pulp's Celery settings. These settings are used by the Pulp Server and Pulp Workers to
+# perform asynchronous, server-side task work such as syncing, publishing, or deletion of content.
+# Communication between these different components occurs through the broker.
 #
-# broker_url: 		  A URL to a broker that Celery can use to queue tasks. For example, to
-#                     configure Celery with a Qpid backend, set broker_url to:
+# broker_url: A URL to a broker that Celery can use to queue tasks. For example, to configure
+#     Celery with a Qpid backend, set broker_url to:
 #
-#                       qpid://<username>:<password>@<hostname>:<port>/
+#         qpid://<username>:<password>@<hostname>:<port>/
 #
-#                     For RabbitMQ you can use the following broker_url style:
+#     For RabbitMQ you can use the following broker_url style:
 #
-#                       amqp://<username>:<password>@<hostname>:<port>/<vhost>
+#         amqp://<username>:<password>@<hostname>:<port>/<vhost>
 #
-# celery_require_ssl:  Whether or not Celery should use SSL when connecting to the message broker.
-#                      This should be "true", or "false".
-# cacert:			   A path to the CA certificate that should be used to authenticate the broker.
-# keyfile:			   A path to the private key that should be used with the client certificate
-#                      when connecting to the broker.
-# certfile:			   A path to the client certificate that should be used when connecting to the
-#                      broker.
+# celery_require_ssl: Require SSL if set to 'true', otherwise do not require SSL. The default is
+#     'false'.
+#
+# cacert: The absolute path to the PEM encoded CA Certificate allowing identity validation of the
+#     message bus. The default is '/etc/pki/pulp/qpid/ca.crt'.
+#
+# keyfile: The absolute path to the keyfile used for authentication to the message bus. This is the
+#     private key that corresponds with the certificate. The default value is
+#     '/etc/pki/pulp/qpid/client.crt'. Sometimes the key is kept in the same file as the
+#     certificate it corresponds with, and the default assumes this is the case.
+#
+# certfile: The absolute path to the PEM encoded certificate used for authentication to the message
+#     bus. The default value is '/etc/pki/pulp/qpid/client.crt'.
+#
+
 [tasks]
-broker_url: <%= @broker_url %>
-celery_require_ssl: <%= @broker_use_ssl %>
-cacert: <%= @messaging_ca_cert %>
-keyfile:
-certfile: <%= @messaging_client_cert %>
+broker_url: <%= scope['pulp::broker_url'] %>
+celery_require_ssl: <%= scope['pulp::broker_use_ssl'] %>
+<% if scope['pulp::messaging_ca_cert'] -%>
+cacert: <%= scope['pulp::messaging_ca_cert'] %>
+<% end -%>
+<% if scope['pulp::messaging_client_cert'] -%>
+keyfile: <%= scope['pulp::messaging_client_cert'] %>
+certfile: <%= scope['pulp::messaging_client_cert'] %>
+<% end -%>
 
 
 # = Email =
@@ -285,10 +331,10 @@ certfile: <%= @messaging_client_cert %>
 #
 # from: the "From" address of each email the system sends
 #
-# enabled: booleanl controls whether or not emails will be sent
+# enabled: boolean controls whether or not emails will be sent
 
 [email]
-# host: localhost
-# port: 25
-# from: no-reply@your.domain
-# enabled: false
+host: <%= scope['pulp::email_host'] %>
+port: <%= scope['pulp::email_port'] %>
+from: <%= scope['pulp::email_from'] %>
+enabled: <%= scope['pulp::email_enabled'] %>


### PR DESCRIPTION
This is an intermediate PR (formatting is all broken on purpose )

Other changes:
- renamed consumers_ca_cert and consumers_ca_key to ca_cert and ca_key, in order to keep the same naming as in config file
- removed mongodb_path, qpid_ssl, qpid_ssl_cert_db, qpid_ssl_cert_password_file, user_groups
- changed broker_url and broker_use_ssl to default without ssl

