### PR TITLE
Config file updates, ostree support, and bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ If your most recent release breaks compatibility or requires particular steps fo
 ##Limitations
 
 * EL6,7 (RHEL6,7 / CentOS 6,7)
+* Requires Pulp 2.7.0 or higher.
 
 ##Pulp consumer
 

--- a/manifests/admin.pp
+++ b/manifests/admin.pp
@@ -66,6 +66,9 @@
 # $enable_python::                 Install python extension. Defaults to false.
 #                                  type:boolean
 #
+# $enable_ostree::                 Install ostree extension. Defaults to false.
+#                                  type:boolean
+#
 # $enable_rpm::                    Install rpm extension. Defaults to true.
 #                                  type:boolean
 #
@@ -97,6 +100,7 @@ class pulp::admin (
   $enable_docker             = $pulp::admin::params::enable_docker,
   $enable_nodes              = $pulp::admin::params::enable_nodes,
   $enable_python             = $pulp::admin::params::enable_python,
+  $enable_ostree             = $pulp::admin::params::enable_ostree,
   $enable_rpm                = $pulp::admin::params::enable_rpm,
   $puppet_upload_working_dir = $pulp::admin::params::puppet_upload_working_dir,
   $puppet_upload_chunk_size  = $pulp::admin::params::puppet_upload_chunk_size,
@@ -105,6 +109,7 @@ class pulp::admin (
   validate_bool($enable_docker)
   validate_bool($enable_nodes)
   validate_bool($enable_python)
+  validate_bool($enable_ostree)
   validate_bool($enable_rpm)
 
   validate_bool($verify_ssl)

--- a/manifests/admin/install.pp
+++ b/manifests/admin/install.pp
@@ -29,6 +29,12 @@ class pulp::admin::install {
     }
   }
 
+  if $pulp::admin::enable_ostree {
+    package { 'pulp-ostree-admin-extensions':
+      ensure => $pulp::admin::version,
+    }
+  }
+
   if $pulp::admin::enable_rpm {
     package { 'pulp-rpm-admin-extensions':
       ensure => $pulp::admin::version,

--- a/manifests/admin/params.pp
+++ b/manifests/admin/params.pp
@@ -22,6 +22,7 @@ class pulp::admin::params {
   $enable_docker      = false
   $enable_nodes       = false
   $enable_python      = false
+  $enable_ostree      = false
   $enable_rpm         = true
 
   $puppet_upload_working_dir = '~/.pulp/puppet-uploads'

--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -25,7 +25,7 @@ class pulp::apache {
       ssl                        => true,
       ssl_cert                   => $pulp::https_cert,
       ssl_key                    => $pulp::https_key,
-      ssl_ca                     => $pulp::ca_cert,
+      ssl_ca                     => $pulp::ssl_ca_cert,
       ssl_verify_client          => 'optional',
       ssl_protocol               => ' all -SSLv2',
       ssl_options                => '+StdEnvVars +ExportCertData',
@@ -39,9 +39,9 @@ class pulp::apache {
         'process-group'     => 'pulp',
         'application-group' => 'pulp',
       },
-      wsgi_script_aliases        => {
-        '/pulp/api' => '/srv/pulp/webservices.wsgi',
-      },
+      wsgi_script_aliases        => merge(
+        {'/pulp/api'=>'/srv/pulp/webservices.wsgi'},
+        $pulp::additional_wsgi_scripts),
       directories                => [
         {
           'path'     => 'webservices.wsgi',
@@ -93,6 +93,10 @@ class pulp::apache {
 
     if $pulp::enable_python {
       pulp::apache_plugin { 'python': }
+    }
+
+    if $pulp::enable_ostree {
+      pulp::apache_plugin { 'ostree': }
     }
 
     if $pulp::enable_parent_node {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -107,6 +107,12 @@
 #
 # $consumer_cert_expiration::   number of days a consumer certificate is valid
 #
+# $disabled_authenticators::    List of repo authenticators to disable.
+#                               type:array
+#
+# $additional_wsgi_scripts::    Hash of additional paths and WSGI script locations for Pulp vhost
+#                               type:hash
+#
 # $reset_cache::                Boolean to flush the cache. Defaults to false
 #                               type:boolean
 #
@@ -162,6 +168,10 @@
 #                               type:boolean
 #
 # $enable_python::              Boolean to enable python plugin. Defaults
+#                               to false
+#                               type:boolean
+#
+# $enable_ostree::              Boolean to enable ostree plugin. Defaults
 #                               to false
 #                               type:boolean
 #
@@ -259,6 +269,7 @@ class pulp (
   $enable_rpm                = $pulp::params::enable_rpm,
   $enable_puppet             = $pulp::params::enable_puppet,
   $enable_python             = $pulp::params::enable_python,
+  $enable_ostree             = $pulp::params::enable_ostree,
   $enable_parent_node        = $pulp::params::enable_parent_node,
   $enable_http               = $pulp::params::enable_http,
   $manage_broker             = $pulp::params::manage_broker,
@@ -271,19 +282,24 @@ class pulp (
   $node_oauth_effective_user = $pulp::params::node_oauth_effective_user,
   $node_oauth_key            = $pulp::params::node_oauth_key,
   $node_oauth_secret         = $pulp::params::node_oauth_secret,
+  $disabled_authenticators   = $pulp::params::disabled_authenticators,
+  $additional_wsgi_scripts   = $pulp::params::additional_wsgi_scripts,
 ) inherits pulp::params {
-  validate_bool($repo_auth)
-  validate_bool($reset_cache)
   validate_bool($enable_docker)
   validate_bool($enable_rpm)
   validate_bool($enable_puppet)
   validate_bool($enable_python)
+  validate_bool($enable_ostree)
   validate_bool($enable_http)
   validate_bool($manage_db)
   validate_bool($manage_broker)
   validate_bool($manage_httpd)
   validate_bool($manage_plugins_httpd)
   validate_bool($enable_parent_node)
+  validate_bool($repo_auth)
+  validate_bool($reset_cache)
+  validate_array($disabled_authenticators)
+  validate_hash($additional_wsgi_scripts)
 
   include ::mongodb::client
   include ::pulp::apache

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -52,6 +52,7 @@ class pulp::params {
 
   $enable_rpm = true
   $enable_docker = false
+  $enable_ostree = false
   $enable_puppet = false
   $enable_python = false
   $enable_parent_node = false
@@ -73,6 +74,8 @@ class pulp::params {
   $default_password = cache_data('foreman_cache_data', 'pulp_password', random_password(32))
 
   $repo_auth = false
+  $disabled_authenticators = []
+  $additional_wsgi_scripts = {}
 
   $proxy_url = undef
   $proxy_port = undef

--- a/templates/etc/httpd/conf.d/pulp_ostree.conf.erb
+++ b/templates/etc/httpd/conf.d/pulp_ostree.conf.erb
@@ -1,0 +1,16 @@
+#
+# Apache configuration file for Pulp's ostree support
+#
+
+# -- HTTPS Repositories ---------
+
+Alias /pulp/ostree /var/www/pub/ostree/
+
+<Directory /var/www/pub/ostree>
+    WSGIAccessScript /srv/pulp/repo_auth.wsgi
+    SSLRequireSSL
+    SSLVerifyClient <%= scope['pulp::ssl_verify_client'] %>
+    SSLVerifyDepth 2
+    SSLOptions +StdEnvVars +ExportCertData +FakeBasicAuth
+    Options FollowSymLinks Indexes
+</Directory>

--- a/templates/repo_auth.conf.erb
+++ b/templates/repo_auth.conf.erb
@@ -1,3 +1,5 @@
+# This file is managed by puppet. Changes may be overridden!
+
 [main]
 enabled: <%= @repo_auth ? "true" : "false" %>
 log_failed_cert: true
@@ -10,6 +12,13 @@ max_num_certs_in_chain: 100
 # performance impact, so don't do that unless you need per-repo CAs. It is true by default to
 # maintain backwards compatibility.
 verify_ssl: false
+
+# If set, this disables specific repo auth plugins. More than one plugin can be
+# specified in the form of "plugin1,plugin2,plugin3".
+# disabled_authenticators = oid_validation
+<% if @disabled_authenticators and ! @disabled_authenticators.empty? -%>
+disabled_authenticators =  <%= @disabled_authenticators.compact.join(',') %>
+<% end -%>
 
 [repos]
 cert_location: /etc/pki/pulp/content

--- a/templates/vhosts80/ostree.conf
+++ b/templates/vhosts80/ostree.conf
@@ -1,0 +1,1 @@
+Alias /pulp/ostree /var/www/pub/yum/http/ostree


### PR DESCRIPTION
The repo_auth conf file has been updated to match what is in Pulp 2.7. The
vhost configuration also now allows for adding custom third party wsgi scripts
via the additional_wsgi_scripts hash.

Additionally, changes were made to support ostree and a small bugfix was made
related to ssl_ca_cert.