### PR TITLE
fixes #10716 - migrate pulp when new pulp plugins are installed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ group :test do
   gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem "puppet-syntax"
   gem "puppetlabs_spec_helper"
+  gem 'rspec', '< 3.2.0', {"platforms"=>["ruby_18"]} # https://github.com/rspec/rspec-core/issues/1864
 end
 
 group :development do

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -143,6 +143,16 @@ class pulp::config {
     require   => [Service[mongodb], Service[qpidd], File['/etc/pulp/server.conf']],
   }
 
+  exec {'migrate_again':
+    command     => 'pulp-manage-db',
+    path        => '/bin:/usr/bin',
+    logoutput   => 'on_failure',
+    user        => 'apache',
+    before      => Service['httpd'],
+    require     => [Service[mongodb], Service[qpidd], File['/etc/pulp/server.conf']],
+    refreshonly => true,
+  }
+
   if $pulp::consumers_crl {
     exec { 'setup-crl-symlink':
       command     => "/usr/bin/openssl x509 -in '${pulp::consumers_ca_cert}' -hash -noout | /usr/bin/xargs -I{} /bin/ln -sf '${pulp::consumers_crl}' '/etc/pki/pulp/content/{}.r0'",

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,6 +3,7 @@ class pulp::install {
 
   package{ ['pulp-server', 'pulp-selinux', 'pulp-docker-plugins', 'pulp-rpm-plugins', 'pulp-puppet-plugins', 'pulp-nodes-parent']:
     ensure => installed,
+    notify => Exec['migrate_again'],
   }
 
 }


### PR DESCRIPTION
This is a better alternative to https://github.com/Katello/katello-installer/pull/233.

With https://github.com/Katello/katello-installer/pull/233, we still encounter errors in the logs because the pulp service is started by the installer before the post hook runs.  The post hook fixes it, and pulp is working fine, but the errors in the logs are very ugly.

This is only for pulp-puppet 0.1.  The new version 1.0 does the right thing when additional packages are installed.
