### PR TITLE
Replace mongodb_version fact with get_mongodb_version function to prevent lookups of the mongodb version on hosts that do not include the pulp class. Fixes GH-91

### DIFF
--- a/lib/puppet/parser/functions/get_mongodb_version.rb
+++ b/lib/puppet/parser/functions/get_mongodb_version.rb
@@ -1,5 +1,5 @@
-Facter.add(:mongodb_version) do
-  setcode do
+module Puppet::Parser::Functions
+  newfunction(:get_mongodb_version, :type => :rvalue) do |args|
     commands = ["rpmquery --qf='%{version}-%{release}' mongodb",
                 "repoquery --qf='%{version}-%{release}' mongodb",
                 %[LC_ALL=en_US yum -e 0 -d 0 info mongodb | awk '/^Version/ { version=$3; } /^Release/ { print version "-" $3; exit }']]
@@ -11,6 +11,6 @@ Facter.add(:mongodb_version) do
         break
       end
     end
-    ret
+    return ret
   end
 end

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -1,7 +1,7 @@
 # Set up the pulp database
-class pulp::database {
+class pulp::database inherits pulp::params {
   if $pulp::manage_db {
-    if (versioncmp($::mongodb_version, '2.6.5') >= 0) {
+    if (versioncmp($pulp::params::mongodb_version, '2.6.5') >= 0) {
       $mongodb_pidfilepath = '/var/run/mongodb/mongod.pid'
     } else {
       $mongodb_pidfilepath = '/var/run/mongodb/mongodb.pid'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -89,6 +89,8 @@ class pulp::params {
 
   $osreleasemajor = regsubst($::operatingsystemrelease, '^(\d+)\..*$', '\1')
 
+  $mongodb_version = get_mongodb_version()
+
   case $::osfamily {
     'RedHat' : {
       case $osreleasemajor {


### PR DESCRIPTION
As issue-91, replace the mongodb_version fact with an equivalent get_mongodb_version.

This prevents hosts not running pulp from querying their available mongodb versions. 

This also removes the non-obvious "facts.rb" fact file name, cleaning up host facts directory. 

Travis tests appear to pass, and the following basic test also works:

modules$ cat pulp/manifests/foo.pp 
class pulp::foo {
  $foo = get_mongodb_version()
  notify { $foo: }
}

modules$ puppet apply --modulepath=. -e "include pulp::foo" --noop
Notice: /Stage[main]/Pulp::Foo/Notify[2.4.14-1.el6]/message: current_value absent, should be 2.4.14-1.el6 (noop)
Notice: Class[Pulp::Foo]: Would have triggered 'refresh' from 1 events
Notice: Stage[main]: Would have triggered 'refresh' from 1 events
Notice: Finished catalog run in 0.06 seconds
