### PR TITLE
Use qpid::tools class

### DIFF
--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -15,7 +15,9 @@ class pulp::broker {
     Service[$broker_service] -> Exec['migrate_pulp_db']
   } else {
     if $pulp::messaging_transport == 'qpid' {
-      package { 'qpid-tools': ensure => installed } -> Class['pulp::service']
+      include ::qpid::tools
+
+      Class['qpid::tools'] -> Class['pulp::service']
     }
   }
 }


### PR DESCRIPTION
Switches to using qpid::tools class instead of ensuring package
directly to prevent duplicate resource errors