### PR TITLE
Remove direct references to Service['qpidd']

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -10,7 +10,7 @@ class pulp::service {
 
   service { 'pulp_celerybeat':
     ensure     => running,
-    require    => [Service[mongodb], Service[qpidd]],
+    require    => [Service[mongodb]],
     enable     => true,
     hasstatus  => true,
     hasrestart => true,
@@ -18,7 +18,7 @@ class pulp::service {
 
   service { 'pulp_workers':
     ensure     => running,
-    require    => [Service[mongodb], Service[qpidd]],
+    require    => [Service[mongodb]],
     enable     => true,
     hasstatus  => true,
     hasrestart => true,
@@ -27,7 +27,7 @@ class pulp::service {
 
   service { 'pulp_resource_manager':
     ensure     => running,
-    require    => [Service[mongodb], Service[qpidd]],
+    require    => [Service[mongodb]],
     enable     => true,
     hasstatus  => true,
     hasrestart => true,


### PR DESCRIPTION
The broker.pp handles the relationships for the broker services in
a generic manner. Thus, the requires in the service.pp on the broker
service is unneeded.