### PR TITLE
Mongodb fact refactor

### DIFF
--- a/lib/facter/facts.rb
+++ b/lib/facter/facts.rb
@@ -2,7 +2,7 @@ Facter.add(:mongodb_version) do
   setcode do
     commands = ["rpmquery --qf='%{version}-%{release}' mongodb",
                 "repoquery --qf='%{version}-%{release}' mongodb",
-                %[LC_ALL=en_US yum -e 0 -d 0 info mongodb | awk '/^Version/ { version=$3; } /^Release/ { print version "-" $3; exit }']]
+                %[LC_ALL=en_US yum -e 0 -d 0 info mongodb 2>&1 | awk '/^Version/ { version=$3; } /^Release/ { print version "-" $3; exit }']]
     ret = nil
     commands.each do |command|
       version = `#{command}`.chomp

--- a/lib/facter/facts.rb
+++ b/lib/facter/facts.rb
@@ -10,7 +10,7 @@ Facter.add(:mongodb_version) do
     commands.each do |command|
       exe = command.partition(' ').first
       if system("which #{exe} > /dev/null 2>&1")
-        version = `#{command}`.chomp
+        version = `#{command} 2> /dev/null`.chomp
         if $?.success? && !version.empty?
           ret = version
           break

--- a/lib/facter/facts.rb
+++ b/lib/facter/facts.rb
@@ -1,14 +1,20 @@
 Facter.add(:mongodb_version) do
   setcode do
-    commands = ["rpmquery --qf='%{version}-%{release}' mongodb",
-                "repoquery --qf='%{version}-%{release}' mongodb",
-                %[LC_ALL=en_US yum -e 0 -d 0 info mongodb 2>&1 | awk '/^Version/ { version=$3; } /^Release/ { print version "-" $3; exit }']]
+    ENV['LC_ALL'] = 'en_US'
+    commands = [
+      "rpmquery --qf='%{version}-%{release}' mongodb",
+      "repoquery --qf='%{version}-%{release}' mongodb",
+      %[yum -e 0 -d 0 info mongodb 2>&1 | awk '/^Version/ { version=$3; } /^Release/ { print version "-" $3; exit }']
+    ]
     ret = nil
     commands.each do |command|
-      version = `#{command}`.chomp
-      if $?.success? && !version.empty?
-        ret = version
-        break
+      exe = command.partition(' ').first
+      if system("which #{exe} > /dev/null 2>&1")
+        version = `#{command}`.chomp
+        if $?.success? && !version.empty?
+          ret = version
+          break
+        end
       end
     end
     ret


### PR DESCRIPTION
Here is a proposed fix for the following issues:
* executing repoquery on a box without yum-utils causes `sh: repoquery: command not found` to be output
* if STDERR is not redirected for the `yum info` command,  the command outputs `Error: No matching Packages to list`