### PR TITLE
make pulp streamer optional

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -117,11 +117,14 @@ class pulp::apache {
     }
   }
 
-  file {'/etc/httpd/conf.d/pulp_streamer.conf':
-    ensure  => file,
-    content => template('pulp/etc/httpd/conf.d/pulp_streamer.conf.erb'),
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
+  if $pulp::enable_streamer {
+    include ::apache::mod::proxy
+    file {'/etc/httpd/conf.d/pulp_streamer.conf':
+      ensure  => file,
+      content => template('pulp/etc/httpd/conf.d/pulp_streamer.conf.erb'),
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -309,6 +309,7 @@ class pulp (
   $lazy_https_retrieval      = $pulp::params::lazy_https_retrieval,
   $lazy_download_interval    = $pulp::params::lazy_download_interval,
   $lazy_download_concurrency = $pulp::params::lazy_download_concurrency,
+  $enable_streamer           = $pulp::params::enable_streamer,
   $consumers_crl             = $pulp::params::consumers_crl,
   $reset_cache               = $pulp::params::reset_cache,
   $ssl_verify_client         = $pulp::params::ssl_verify_client,
@@ -349,6 +350,7 @@ class pulp (
   validate_bool($manage_httpd)
   validate_bool($manage_plugins_httpd)
   validate_bool($enable_parent_node)
+  validate_bool($enable_streamer)
   validate_bool($repo_auth)
   validate_bool($reset_cache)
   validate_bool($db_unsafe_autoretry)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,13 +1,17 @@
 # Pulp Installation Packages
 # Private class
 class pulp::install {
-  package { ['pulp-server', 'pulp-selinux', 'python-pulp-streamer']: ensure => $pulp::version, }
+  package { ['pulp-server', 'pulp-selinux']: ensure => $pulp::version, }
 
   if $pulp::messaging_transport == 'qpid' {
     ensure_packages(['python-gofer-qpid'], {
       ensure => $pulp::version
     }
     )
+  }
+
+  if $pulp::enable_streamer {
+    package { 'python-pulp-streamer': ensure => $pulp::version, }
   }
 
   if $pulp::messaging_transport == 'rabbitmq' {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -75,6 +75,8 @@ class pulp::params {
   $lazy_download_interval = 10
   $lazy_download_concurrency = 5
 
+  $enable_streamer = true
+
   $consumers_crl = undef
 
   $manage_db = true

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,9 +1,10 @@
 # Pulp Master Service
 class pulp::service {
   if $::operatingsystemmajrelease == 7 {
+
     exec { 'pulp refresh system service':
       command     => '/bin/systemctl daemon-reload',
-      before      => Service['pulp_celerybeat', 'pulp_workers', 'pulp_resource_manager', 'pulp_streamer'],
+      before      => $servicelist,
       refreshonly => true,
     }
   }
@@ -34,11 +35,16 @@ class pulp::service {
     status     => 'service pulp_resource_manager status | grep "node resource_manager"',
   }
 
-  service { 'pulp_streamer':
-    ensure     => running,
-    require    => [Service[mongodb]],
-    enable     => true,
-    hasstatus  => true,
-    hasrestart => true,
+  if $pulp::enable_streamer {
+    $servicelist =  Service['pulp_celerybeat', 'pulp_workers', 'pulp_resource_manager', 'pulp_streamer']
+    service { 'pulp_streamer':
+      ensure     => running,
+      require    => [Service[mongodb]],
+      enable     => true,
+      hasstatus  => true,
+      hasrestart => true,
+    }
+  } else {
+     $servicelist = Service['pulp_celerybeat', 'pulp_workers', 'pulp_resource_manager']
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -45,6 +45,6 @@ class pulp::service {
       hasrestart => true,
     }
   } else {
-     $servicelist = Service['pulp_celerybeat', 'pulp_workers', 'pulp_resource_manager']
+    $servicelist = Service['pulp_celerybeat', 'pulp_workers', 'pulp_resource_manager']
   }
 }


### PR DESCRIPTION
make pulp_streamer installation optional and include apache::mod::proxy in the event that pulp_streamer is included with the apache config added in https://github.com/Katello/puppet-pulp/commit/3e9195baca54a50745b591e16ac8ff501134d26a