### PR TITLE
update to add defaultsite to squid conf

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -106,7 +106,7 @@ class pulp::config {
     }
     class { '::squid3':
       use_deprecated_opts           => $deprecated_opts,
-      http_port                     => [ '3128 accel' ],
+      http_port                     => [ '3128 accel defaultsite=127.0.0.1:8751' ],
       acl                           => [ 'Safe_ports port 3128' ],
       http_access                   => [ 'allow localhost', 'deny to_localhost', 'deny all' ],
       cache                         => [ 'allow all' ],


### PR DESCRIPTION
Squid 3.1 (el6/centos6 default version) requires this directive to be set for
the Pulp streamer. Without it, the streamer will return 400 errors.