### PR TITLE
refs #15058 - mongo auth only on newer mongos

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ If your most recent release breaks compatibility or requires particular steps fo
 
 * EL6,7 (RHEL6,7 / CentOS 6,7)
 * Requires Pulp 2.7.0 or higher.
+* Database authentication parameters are ignored when running MongoDB older than 2.6
 
 ##Pulp consumer
 

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -7,7 +7,12 @@ class pulp::database {
       $mongodb_pidfilepath = '/var/run/mongodb/mongodb.pid'
     }
 
-    $auth_real = $::pulp::db_username != undef and $::pulp::db_password != undef
+    # puppetlabs-mongodb is totally broken with managing users on < 2.6
+    if (versioncmp($::mongodb_version, '2.6.0') >= 0) {
+      $auth_real = $::pulp::db_username != undef and $::pulp::db_password != undef
+    } else {
+      $auth_real = false
+    }
 
     class { '::mongodb::server':
       pidfilepath => $mongodb_pidfilepath,

--- a/spec/classes/pulp_config_spec.rb
+++ b/spec/classes/pulp_config_spec.rb
@@ -10,7 +10,8 @@ describe 'pulp::config' do
       :operatingsystemrelease     => '6.4',
       :operatingsystemmajrelease  => '6.4',
       :osfamily                   => 'RedHat',
-      :processorcount             => 3
+      :processorcount             => 3,
+      :mongodb_version            => '2.4.9',
     }
   end
 
@@ -55,6 +56,44 @@ describe 'pulp::config' do
     it 'should configure server.conf' do
       should contain_file('/etc/pulp/server.conf').
         with_content(/^topic_exchange: 'amq.topic'$/)
+    end
+  end
+
+  context 'with database auth parameters on unsupported mongo' do
+    let :pre_condition do
+      "class {'pulp':
+        db_username => 'rspec',
+        db_password => 'rsp3c4l1f3',
+       }"
+    end
+
+    let :facts do
+      default_facts
+    end
+
+    it "should not configure auth" do
+      should contain_file('/etc/pulp/server.conf').
+        without_content(/^username: rspec$/).
+        without_content(/^password: rsp3c4l1f3$/)
+    end
+  end
+
+  context 'with database auth parameters on supported mongo' do
+    let :pre_condition do
+      "class {'pulp':
+        db_username => 'rspec',
+        db_password => 'rsp3c4l1f3',
+       }"
+    end
+
+    let :facts do
+      default_facts.merge(:mongodb_version => '2.6.1')
+    end
+
+    it "should configure auth" do
+      should contain_file('/etc/pulp/server.conf').
+        with_content(/^username: rspec$/).
+        with_content(/^password: rsp3c4l1f3$/)
     end
   end
 

--- a/templates/server.conf.erb
+++ b/templates/server.conf.erb
@@ -47,11 +47,15 @@
 [database]
 name: <%= scope['pulp::db_name'] %>
 seeds: <%= scope['pulp::db_seeds'] %>
+<%# Auth is currently only working on mongo >= 2.6 -%>
+<% mongo_version = scope.lookupvar('::mongodb_version') -%>
+<% if mongo_version && scope.function_versioncmp([mongo_version, '2.6.0']) >= 0 -%>
 <% unless [nil, :undefined, :undef, ''].include?(scope.lookupvar('pulp::db_username')) -%>
 username: <%= scope['pulp::db_username'] %>
 <% end -%>
 <% unless [nil, :undefined, :undef, ''].include?(scope.lookupvar('pulp::db_password')) -%>
 password: <%= scope['pulp::db_password'] %>
+<% end -%>
 <% end -%>
 <% unless [nil, :undefined, :undef, ''].include?(scope.lookupvar('pulp::db_replica_set')) -%>
 replica_set: <%= scope['pulp::db_replica_set'] %>


### PR DESCRIPTION
puppetlabs-mongodb doesn't manage users correctly on < 2.6.