### PR TITLE
refs #15326 - remove mongo authentication

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -7,29 +7,8 @@ class pulp::database {
       $mongodb_pidfilepath = '/var/run/mongodb/mongodb.pid'
     }
 
-    # puppetlabs-mongodb is totally broken with managing users on < 2.6
-    if (versioncmp($::mongodb_version, '2.6.0') >= 0) {
-      $auth_real = $::pulp::db_username != undef and $::pulp::db_password != undef
-    } else {
-      $auth_real = false
-    }
-
     class { '::mongodb::server':
       pidfilepath => $mongodb_pidfilepath,
-      auth        => $auth_real,
-      noauth      => !$auth_real,
-    }
-
-    if $auth_real {
-      mongodb_user { $::pulp::db_username:
-        ensure        => present,
-        username      => $::pulp::db_username,
-        password_hash => mongodb_password($::pulp::db_username, $::pulp::db_password),
-        database      => $::pulp::db_name,
-        roles         => ['dbAdmin', 'readWrite'],
-        tries         => 10,
-        require       => Service['mongodb'],
-      }
     }
 
     Service['mongodb'] -> Service['pulp_celerybeat']


### PR DESCRIPTION
It is broken on RHEL 6, and does not seem to function reliably on
RHEL 7.  Subsequent runs of the installer will generate errors.

Because of https://tickets.puppetlabs.com/browse/MODULES-534, it  seems, which remains unfixed for quite some time.  It seems clear to me know *why* auth is false by default in this thing, the module is really flaky.  

Since we're planning to drop mongo in a future release anyway, I think it's best just to leave it off on el6 and el7 now too.

Any thoughts on this?