### PR TITLE
fixes GH-150 - Eliminate duplicate, broken requires on mongodb

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -14,6 +14,7 @@ class pulp::database {
     Service['mongodb'] -> Service['pulp_celerybeat']
     Service['mongodb'] -> Service['pulp_workers']
     Service['mongodb'] -> Service['pulp_resource_manager']
+    Service['mongodb'] -> Service['pulp_streamer']
     Service['mongodb'] -> Exec['migrate_pulp_db']
   }
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -10,7 +10,6 @@ class pulp::service {
 
   service { 'pulp_celerybeat':
     ensure     => running,
-    require    => [Service[mongodb]],
     enable     => true,
     hasstatus  => true,
     hasrestart => true,
@@ -18,7 +17,6 @@ class pulp::service {
 
   service { 'pulp_workers':
     ensure     => running,
-    require    => [Service[mongodb]],
     enable     => true,
     hasstatus  => true,
     hasrestart => true,
@@ -27,7 +25,6 @@ class pulp::service {
 
   service { 'pulp_resource_manager':
     ensure     => running,
-    require    => [Service[mongodb]],
     enable     => true,
     hasstatus  => true,
     hasrestart => true,
@@ -36,7 +33,6 @@ class pulp::service {
 
   service { 'pulp_streamer':
     ensure     => running,
-    require    => [Service[mongodb]],
     enable     => true,
     hasstatus  => true,
     hasrestart => true,


### PR DESCRIPTION
This is a fix for https://github.com/Katello/puppet-pulp/issues/150: it deletes duplicate requires and, more important, let them be included in the catalogue only if the resource "service['mongodb']" has been created.

This change should make the module work for people using "manage_db=false" (e.g. MongoDB installed on another node).