### PR TITLE
Do not attempt to write `vhosts80` file too early

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -86,11 +86,12 @@ class pulp::apache {
     pulp::apache_plugin {'content' : vhosts80 => false}
 
     file { '/etc/pulp/vhosts80/':
-      ensure => directory,
-      owner  => 'apache',
-      group  => 'apache',
-      mode   => '0755',
-      purge  => true,
+      ensure  => directory,
+      owner   => 'apache',
+      group   => 'apache',
+      mode    => '0755',
+      purge   => true,
+      require => Package['pulp-server'],
     }
 
     if $pulp::enable_rpm {


### PR DESCRIPTION
Puppet was attempting to create `/etc/pulp/vhosts80` before `pulp-server` was
installed.  This led to errors because `/etc/pulp` didn't exist yet.