### PR TITLE
Fixes #16343 - Redirect fix for Atomic Hosts

### DIFF
--- a/spec/classes/pulp_apache_spec.rb
+++ b/spec/classes/pulp_apache_spec.rb
@@ -311,7 +311,6 @@ Alias /pulp/python /var/www/pub/python/
       end
     end
 
-
     describe 'with enable_ostree' do
       let :pre_condition do
         "class {'pulp': enable_ostree => true}"
@@ -322,6 +321,8 @@ Alias /pulp/python /var/www/pub/python/
         :content => '#
 # Apache configuration file for Pulp\'s OSTree support
 #
+RedirectMatch "^/pulp/ostree/web/(.*?)/repodata/(.*)"  "/pulp/repos/$1/repodata/$2"
+RedirectMatch "^/pulp/ostree/web/(.*?)\.rpm"  "/pulp/repos/$1.rpm"
 
 # -- HTTPS Repositories ---------
 

--- a/templates/etc/httpd/conf.d/pulp_ostree.conf.erb
+++ b/templates/etc/httpd/conf.d/pulp_ostree.conf.erb
@@ -1,6 +1,8 @@
 #
 # Apache configuration file for Pulp's OSTree support
 #
+RedirectMatch "^/pulp/ostree/web/(.*?)/repodata/(.*)"  "/pulp/repos/$1/repodata/$2"
+RedirectMatch "^/pulp/ostree/web/(.*?)\.rpm"  "/pulp/repos/$1.rpm"
 
 # -- HTTPS Repositories ---------
 


### PR DESCRIPTION
Rhel 7 Docker Containers inside an Atomic host need to be able to pull
rpms from within /pulp/ostree/web/. But those are available only under
/pulp/repos

This commit sets up a config to redirect 'yum repo like' calls to
/pulp/repos to facilitate that