### PR TITLE
this fact make a useless warn message

### DIFF
--- a/lib/facter/facts.rb
+++ b/lib/facter/facts.rb
@@ -1,7 +1,7 @@
 Facter.add(:mongodb_version) do
   setcode do
     commands = ["rpmquery --qf='%{version}-%{release}' mongodb",
-                "repoquery --qf='%{version}-%{release}' mongodb",
+                "repoquery --qf='%{version}-%{release}' mongodb 2>/dev/null",
                 %[LC_ALL=en_US yum -e 0 -d 0 info mongodb | awk '/^Version/ { version=$3; } /^Release/ { print version "-" $3; exit }']]
     ret = nil
     commands.each do |command|


### PR DESCRIPTION
rpmquery is provide by rpm but repoquery is in yum-utils

we have this message on several agents :
sh: repoquery: command not found