### PR TITLE
ssl_protocol: customisable parameter and default avoids SSLv3

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -32,7 +32,7 @@ class pulp::apache {
       ssl_chain                  => $pulp::https_chain,
       ssl_ca                     => $pulp::ca_cert,
       ssl_verify_client          => 'optional',
-      ssl_protocol               => ' all -SSLv2',
+      ssl_protocol               => $pulp::ssl_protocol,
       ssl_options                => '+StdEnvVars +ExportCertData',
       ssl_verify_depth           => '3',
       wsgi_process_group         => 'pulp',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -129,6 +129,8 @@
 #
 # $ssl_verify_client::          Enforce use of SSL authentication for yum repos access
 #
+# $ssl_protocol::               List which versions of the SSL/TLS protocol will be accepted in new connections
+#
 # $serial_number_path::         Path to the serial number file
 #
 # $consumer_history_lifetime::  number of days to store consumer events; events older
@@ -318,6 +320,7 @@ class pulp (
   $consumers_crl             = $pulp::params::consumers_crl,
   $reset_cache               = $pulp::params::reset_cache,
   $ssl_verify_client         = $pulp::params::ssl_verify_client,
+  $ssl_protocol              = $pulp::params::ssl_protocol,
   $repo_auth                 = $pulp::params::repo_auth,
   $proxy_url                 = $pulp::params::proxy_url,
   $proxy_port                = $pulp::params::proxy_port,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -377,6 +377,9 @@ class pulp (
   if $https_chain {
     validate_absolute_path($https_chain)
   }
+  if $ssl_protocol != undef {
+    validate_string($ssl_protocol)
+  }
 
   include ::mongodb::client
   include ::pulp::apache

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -55,6 +55,7 @@ class pulp::params {
   $https_chain = undef
   $enable_http = false
   $ssl_verify_client = 'require'
+  $ssl_protocol = 'all -SSLv2 -SSLv3'
 
   $enable_rpm = true
   $enable_docker = false

--- a/spec/classes/pulp_apache_spec.rb
+++ b/spec/classes/pulp_apache_spec.rb
@@ -31,7 +31,7 @@ describe 'pulp::apache' do
         :docroot                 => '/usr/share/pulp/wsgi',
         :ssl                     => true,
         :ssl_verify_client       => 'optional',
-        :ssl_protocol            => ' all -SSLv2',
+        :ssl_protocol            => 'all -SSLv2 -SSLv3',
         :ssl_options             => '+StdEnvVars +ExportCertData',
         :ssl_verify_depth        => '3',
         :wsgi_process_group      => 'pulp',
@@ -46,6 +46,14 @@ describe 'pulp::apache' do
   context 'with parameters' do
     let :facts do
       default_facts
+    end
+
+    describe 'with ssl_protocol some_string' do
+      let :pre_condition do
+        "class {'pulp': ssl_protocol => 'some_string'}"
+      end
+
+      it { should contain_apache__vhost('pulp-https').with_ssl_protocol('some_string')}
     end
 
     describe 'with enable_http false' do


### PR DESCRIPTION
The SSLProtocol directive is hardcoded as "_all -SSLv2_" in the _pulp-https_ vhost ressource declaration. Puppetlabs/apache would have put it to "_all -SSLv2 -SSLv3_" by default, because SSLv3 is now deprecated (RFC 7568).
This PR makes _ssl_protocol_ a customisable parameter and sets its default value to the current apache module default.