### PR TITLE
allow to increase the timeout for the exec that does the db migration

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -25,6 +25,7 @@ class pulp::database {
     user      => 'apache',
     creates   => '/var/lib/pulp/init.flag',
     require   => File['/etc/pulp/server.conf'],
+    timeout   => $pulp::migrate_db_timeout,
   }
 
   Class['pulp::install'] ~> Exec['migrate_pulp_db'] ~> Class['pulp::service']

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -259,6 +259,9 @@
 #
 # $puppet_wsgi_processes::      Number of WSGI processes to spawn for the puppet webapp
 #
+# $migrate_db_timeout::         Change the timeout for pulp-manage-db
+#                               type:integer
+#
 class pulp (
   $version                   = $pulp::params::version,
   $db_name                   = $pulp::params::db_name,
@@ -348,6 +351,7 @@ class pulp (
   $disabled_authenticators   = $pulp::params::disabled_authenticators,
   $additional_wsgi_scripts   = $pulp::params::additional_wsgi_scripts,
   $puppet_wsgi_processes     = $pulp::params::puppet_wsgi_processes,
+  $migrate_db_timeout        = $pulp::params::migrate_db_timeout,
 ) inherits pulp::params {
   validate_bool($enable_docker)
   validate_bool($enable_rpm)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,7 @@ class pulp::params {
   $db_ca_path = '/etc/pki/tls/certs/ca-bundle.crt'
   $db_unsafe_autoretry = false
   $db_write_concern = undef
+  $migrate_db_timeout = 300
 
   $server_name = downcase($::fqdn)
   $key_url = '/pulp/gpg'


### PR DESCRIPTION
On our machines the exec  'migrate_pulp_db' times out during pulp upgrades. To fix this we have to run the command manually on all servers.

This parameter should fix this issue.
