### PR TITLE
fixes GH-171 - add a show_conf_diff param, defaults to false

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -9,11 +9,12 @@ class pulp::config {
   }
 
   file { '/etc/pulp/server.conf':
-    ensure  => file,
-    content => template('pulp/server.conf.erb'),
-    owner   => 'apache',
-    group   => 'apache',
-    mode    => '0600',
+    ensure    => file,
+    content   => template('pulp/server.conf.erb'),
+    owner     => 'apache',
+    group     => 'apache',
+    mode      => '0600',
+    show_diff => $pulp::show_conf_diff,
   }
 
   file { '/etc/pki/pulp/content/pulp-global-repo.ca':

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -32,29 +32,32 @@ class pulp::config {
     }
 
     file { '/etc/pulp/server/plugins.conf.d/yum_importer.json':
-      ensure  => file,
-      content => template('pulp/yum_importer.json.erb'),
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0644',
+      ensure    => file,
+      content   => template('pulp/yum_importer.json.erb'),
+      owner     => 'root',
+      group     => 'root',
+      mode      => '0644',
+      show_diff => $pulp::show_conf_diff,
     }
 
     file { '/etc/pulp/server/plugins.conf.d/iso_importer.json':
-      ensure  => file,
-      content => template('pulp/iso_importer.json.erb'),
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0644',
+      ensure    => file,
+      content   => template('pulp/iso_importer.json.erb'),
+      owner     => 'root',
+      group     => 'root',
+      mode      => '0644',
+      show_diff => $pulp::show_conf_diff,
     }
   }
 
   if $pulp::enable_docker {
     file { '/etc/pulp/server/plugins.conf.d/docker_importer.json':
-      ensure  => file,
-      content => template('pulp/docker_importer.json.erb'),
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0644',
+      ensure    => file,
+      content   => template('pulp/docker_importer.json.erb'),
+      owner     => 'root',
+      group     => 'root',
+      mode      => '0644',
+      show_diff => $pulp::show_conf_diff,
     }
   }
 
@@ -66,11 +69,12 @@ class pulp::config {
     }
 
     file { '/etc/pulp/server/plugins.conf.d/puppet_importer.json':
-      ensure  => file,
-      content => template('pulp/puppet_importer.json.erb'),
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0644',
+      ensure    => file,
+      content   => template('pulp/puppet_importer.json.erb'),
+      owner     => 'root',
+      group     => 'root',
+      mode      => '0644',
+      show_diff => $pulp::show_conf_diff,
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -264,8 +264,9 @@
 # $migrate_db_timeout::         Change the timeout for pulp-manage-db
 #                               type:integer
 #
-# $show_conf_diff::             Allow showing diff for changes in server.conf; Warning: may display
-#                               and log passwords contained in this file. Defaults to false
+# $show_conf_diff::             Allow showing diff for changes in server.conf and importer.json;
+#                               Warning: may display and log passwords contained in these files.
+#                               Defaults to false
 #                               type:boolean
 # 
 class pulp (

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -264,6 +264,10 @@
 # $migrate_db_timeout::         Change the timeout for pulp-manage-db
 #                               type:integer
 #
+# $show_conf_diff::             Allow showing diff for changes in server.conf; Warning: may display
+#                               and log passwords contained in this file. Defaults to false
+#                               type:boolean
+# 
 class pulp (
   $version                   = $pulp::params::version,
   $db_name                   = $pulp::params::db_name,
@@ -355,6 +359,7 @@ class pulp (
   $additional_wsgi_scripts   = $pulp::params::additional_wsgi_scripts,
   $puppet_wsgi_processes     = $pulp::params::puppet_wsgi_processes,
   $migrate_db_timeout        = $pulp::params::migrate_db_timeout,
+  $show_conf_diff            = $pulp::params::show_conf_diff,
 ) inherits pulp::params {
   validate_bool($enable_docker)
   validate_bool($enable_rpm)
@@ -373,6 +378,7 @@ class pulp (
   validate_bool($messaging_event_notifications_enabled)
   validate_bool($manage_squid)
   validate_bool($lazy_https_retrieval)
+  validate_bool($show_conf_diff)
   validate_array($disabled_authenticators)
   validate_hash($additional_wsgi_scripts)
   validate_integer($max_keep_alive)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -103,6 +103,7 @@ class pulp::params {
   $num_workers = min($::processorcount, 8)
 
   $puppet_wsgi_processes = 3
+  $show_conf_diff = false
 
   $node_certificate = '/etc/pki/pulp/nodes/node.crt'
   $node_verify_ssl = true


### PR DESCRIPTION
These commits avoid displaying any diff by default on files containing passwords. They add a parameter to change this behaviour.