### PR TITLE
Refs #17298 - Add max tasks per Pulp worker

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -416,6 +416,10 @@ class pulp (
   validate_hash($additional_wsgi_scripts)
   validate_integer($max_keep_alive)
 
+  if $max_tasks_per_child {
+    validate_integer($max_tasks_per_child)
+  }
+
   if $https_cert {
     validate_absolute_path($https_cert)
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -217,6 +217,10 @@
 # $enable_crane::               Boolean to enable crane docker repository
 #                               type:boolean
 #
+# $max_tasks_per_child::        Number of tasks after which the worker is restarted
+#                               and the memory it allocated is returned to the system
+#                               type:integer
+#
 # $enable_rpm::                 Boolean to enable rpm plugin. Defaults
 #                               to true
 #                               type:boolean
@@ -287,7 +291,7 @@
 #                               Warning: may display and log passwords contained in these files.
 #                               Defaults to false
 #                               type:boolean
-# 
+#
 class pulp (
   $version                   = $pulp::params::version,
   $crane_debug               = $pulp::params::crane_debug,
@@ -364,6 +368,7 @@ class pulp (
   $num_workers               = $pulp::params::num_workers,
   $enable_katello            = $pulp::params::enable_katello,
   $enable_crane              = $pulp::params::enable_crane,
+  $max_tasks_per_child       = $pulp::params::max_tasks_per_child,
   $enable_docker             = $pulp::params::enable_docker,
   $enable_rpm                = $pulp::params::enable_rpm,
   $enable_puppet             = $pulp::params::enable_puppet,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -107,6 +107,7 @@ class pulp::params {
 
   $max_keep_alive = 10000
   $num_workers = min($::processorcount, 8)
+  $max_tasks_per_child = undef
 
   $yum_max_speed = undef
 

--- a/templates/systemd_pulp_workers
+++ b/templates/systemd_pulp_workers
@@ -6,3 +6,11 @@ PULP_CONCURRENCY=<%= scope['pulp::num_workers'] %>
 
 # Configure Python's encoding for writing all logs, stdout and stderr
 PYTHONIOENCODING="UTF-8"
+
+# To avoid memory leaks, Pulp can terminate and replace a worker after processing X tasks. If
+# left commented, process recycling is disabled. PULP_MAX_TASKS_PER_CHILD must be > 0.
+<% if scope['pulp::max_tasks_per_child'] != :undef and scope['pulp::max_tasks_per_child'].to_i > 0 %>
+PULP_MAX_TASKS_PER_CHILD=<%= scope['pulp::max_tasks_per_child'] %>
+<% else %>
+# PULP_MAX_TASKS_PER_CHILD=2
+<% end %>

--- a/templates/systemd_pulp_workers
+++ b/templates/systemd_pulp_workers
@@ -9,7 +9,7 @@ PYTHONIOENCODING="UTF-8"
 
 # To avoid memory leaks, Pulp can terminate and replace a worker after processing X tasks. If
 # left commented, process recycling is disabled. PULP_MAX_TASKS_PER_CHILD must be > 0.
-<% if scope['pulp::max_tasks_per_child'] != :undef and scope['pulp::max_tasks_per_child'].to_i > 0 %>
+<% if !scope['pulp::max_tasks_per_child'].nil? and scope['pulp::max_tasks_per_child'] > 0 %>
 PULP_MAX_TASKS_PER_CHILD=<%= scope['pulp::max_tasks_per_child'] %>
 <% else %>
 # PULP_MAX_TASKS_PER_CHILD=2

--- a/templates/systemd_pulp_workers
+++ b/templates/systemd_pulp_workers
@@ -9,7 +9,7 @@ PYTHONIOENCODING="UTF-8"
 
 # To avoid memory leaks, Pulp can terminate and replace a worker after processing X tasks. If
 # left commented, process recycling is disabled. PULP_MAX_TASKS_PER_CHILD must be > 0.
-<% if !scope['pulp::max_tasks_per_child'].nil? and scope['pulp::max_tasks_per_child'] > 0 %>
+<% unless [nil, :undefined, :undef, '', 0].include?(scope.lookupvar('pulp::max_tasks_per_child')) %>
 PULP_MAX_TASKS_PER_CHILD=<%= scope['pulp::max_tasks_per_child'] %>
 <% else %>
 # PULP_MAX_TASKS_PER_CHILD=2

--- a/templates/upstart_pulp_workers
+++ b/templates/upstart_pulp_workers
@@ -22,7 +22,7 @@ PYTHONIOENCODING="UTF-8"
 
 # To avoid memory leaks, Pulp can terminate and replace a worker after processing X tasks. If
 # left commented, process recycling is disabled. PULP_MAX_TASKS_PER_CHILD must be > 0.
-<% if !scope['pulp::max_tasks_per_child'].nil? and scope['pulp::max_tasks_per_child'] > 0 %>
+<% unless [nil, :undefined, :undef, '', 0].include?(scope.lookupvar('pulp::max_tasks_per_child')) %>
 PULP_MAX_TASKS_PER_CHILD=<%= scope['pulp::max_tasks_per_child'] %>
 <% else %>
 # PULP_MAX_TASKS_PER_CHILD=2

--- a/templates/upstart_pulp_workers
+++ b/templates/upstart_pulp_workers
@@ -22,7 +22,7 @@ PYTHONIOENCODING="UTF-8"
 
 # To avoid memory leaks, Pulp can terminate and replace a worker after processing X tasks. If
 # left commented, process recycling is disabled. PULP_MAX_TASKS_PER_CHILD must be > 0.
-<% if scope['pulp::max_tasks_per_child'] != :undef and scope['pulp::max_tasks_per_child'].to_i > 0 %>
+<% if !scope['pulp::max_tasks_per_child'].nil? and scope['pulp::max_tasks_per_child'] > 0 %>
 PULP_MAX_TASKS_PER_CHILD=<%= scope['pulp::max_tasks_per_child'] %>
 <% else %>
 # PULP_MAX_TASKS_PER_CHILD=2

--- a/templates/upstart_pulp_workers
+++ b/templates/upstart_pulp_workers
@@ -19,6 +19,15 @@ PULP_CONCURRENCY=<%= scope['pulp::num_workers'] %>
 # Configure Python's encoding for writing all logs, stdout and stderr
 PYTHONIOENCODING="UTF-8"
 
+
+# To avoid memory leaks, Pulp can terminate and replace a worker after processing X tasks. If
+# left commented, process recycling is disabled. PULP_MAX_TASKS_PER_CHILD must be > 0.
+<% if scope['pulp::max_tasks_per_child'] != :undef and scope['pulp::max_tasks_per_child'].to_i > 0 %>
+PULP_MAX_TASKS_PER_CHILD=<%= scope['pulp::max_tasks_per_child'] %>
+<% else %>
+# PULP_MAX_TASKS_PER_CHILD=2
+<% end %>
+
 ######################################################################
 # Please do not edit any of the settings below this mark in this file!
 ######################################################################


### PR DESCRIPTION
!!**Merge once Pulp >= 2.11 is added to Katello**!!

This feature requires Pulp >= 2.11. It allows setting of maximum number of tasks after which the celery worker gets recycled and releses its memory to the system.

Related patch to `puppet-katello` will follow