### PR TITLE
Remove potential for circular dependency when using Apache

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -432,7 +432,7 @@ class pulp (
 
   class { '::pulp::install': } ->
   class { '::pulp::config': } ~>
-  class { '::pulp::service': } ~>
-  Service['httpd'] ->
-  Class[pulp]
+  class { '::pulp::service': } ->
+  Class[pulp] ~>
+  Service['httpd']
 }


### PR DESCRIPTION
If another service is also using Apache, and that service with Pulp
need to be dependently ordered, this can result in circular dependencies.