### PR TITLE
add an schedule provider

### DIFF
--- a/lib/puppet/provider/pulp_schedule/api.rb
+++ b/lib/puppet/provider/pulp_schedule/api.rb
@@ -1,0 +1,167 @@
+#  Limitations:
+# - we can't have multiple schedules for the same repo, so we force the existence of only one schedule per repo 
+#   (the one with the smallest sync_id). The resource name will be the repo_id
+# - user should not set the name of a repo to be the same as an existing schedule_id (probability is very small)
+# - if the repo (resource name) doesn't exists, the resource will fail (normal)
+# - there is a global variable used ($schedules_info)
+#
+# Explanation on how it's implemented:
+# - when we get the resources, we set the resource name to repo_id only for the first schedule
+# - the other schedules get the name = schedule_id (this is useful only for purging)
+# - we need to keep somewhere the schedule_id for the first ones ($schedules_info['schedule_id']): this is needed in update
+# - we need to keep the repo_id for the second ones ($schedules_info['repo_id']): needed in delete, when we purge the resources
+# - since this provider is global for all repos, we need to keep the repo_type for all repos ($schedules_info['repo_type'])
+# - a special case is when we have a single resource defined in puppet with ensure => absent: we keep the schedule id in $schedules_info['repo_id']
+
+require File.expand_path('../../../util/pulp_util', __FILE__)
+
+Puppet::Type.type(:pulp_schedule).provide(:api) do
+  commands :pulp_admin => '/usr/bin/pulp-admin'
+
+  mk_resource_methods
+  $schedules_info ||= Hash.new
+  $schedules_info['repo_id'] ||= Hash.new
+  $schedules_info['schedule_id'] ||= Hash.new
+  $schedules_info['repo_type'] ||= Hash.new
+
+  def initialize(resource={})
+    super(resource)
+    @property_flush = {}
+  end
+
+  def self.get_resource_properties(repo_id)
+    all = []
+    sync_id = nil
+    # get_repo_syncs return an array with all schedules and the repo type
+    schedules =  @pulp.get_repo_syncs(repo_id)
+    return all if !schedules[0]
+    all_schedules = schedules[0]
+    $schedules_info['repo_type'][repo_id] = schedules[1]
+
+    # first get the lowest sync id
+    all_schedules.each { |schedule|
+      if sync_id && sync_id < schedule['_id']
+        sync_id = schedule['_id']
+      elsif !sync_id
+        sync_id = schedule['_id']
+      end
+    }
+
+    # create resources
+    all_schedules.each { |schedule|
+      hash = {}
+      hash[:ensure] = :present
+      hash[:provider] = :pulp_schedule
+
+      # in case where we are the previously saved sync_id, we set this as the _main_ resource
+      if sync_id == schedule['_id']
+        hash[:name] = repo_id
+        $schedules_info['repo_id'][repo_id] = schedule['_id']
+      else
+        # otherwise we create a dummy resource that can be purged if not needed
+        hash[:name] = schedule['_id']
+        $schedules_info['schedule_id'][schedule['_id']] = repo_id
+      end
+
+      hash[:schedule_time] = schedule['schedule']
+      hash[:enabled] = schedule['enabled'] == true ? :true : :false
+      hash[:failure_threshold] = schedule['failure_threshold']
+      all << new(hash)
+    }
+    all
+  end
+
+  def self.instances
+    all = []
+
+    @pulp = Puppet::Util::PulpUtil.new
+    @pulp.get_repos.each { |repo|
+      all << get_resource_properties(repo['id'])
+    }
+    all.flatten
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    @property_flush[:ensure] = :present
+  end
+
+  def destroy
+    @property_flush[:ensure] = :absent
+  end
+
+  # iterates through the array of resources returned by self.instances
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name]
+        resource.provider = prov
+      end
+    end
+  end
+
+  def flush
+    set_schedule
+
+    # Some of the resources have now schedule_id as the name, so we try to fix this
+    if $schedules_info['repo_id'].has_key?(resource[:name])
+      repo_id = resource[:name]
+    else
+      repo_id = $schedules_info['schedule_id'][resource[:name]]
+    end
+
+    # Collect the resources again once they've been changed (that way `puppet
+    # resource` will show the correct values after changes have been made).
+    @property_hash = self.class.get_resource_properties(repo_id)
+  end
+
+  def set_schedule
+    params = []
+    params << ['--schedule', resource[:schedule_time]]
+    params << ['--failure-threshold', resource[:failure_threshold]] if resource[:failure_threshold]
+    repo_id = resource[:name]
+
+    if @property_flush[:ensure] == :absent
+      # delete
+      action = 'delete'
+      if $schedules_info['repo_id'].has_key?(resource[:name])
+        # this is a _main_ resource
+        params = ['--schedule-id', $schedules_info['repo_id'][resource[:name]]]
+      else
+        # this is one of the dummy resources
+        repo_id = $schedules_info['schedule_id'][resource[:name]]
+        params = ['--schedule-id', resource[:name]]
+      end
+    elsif @property_flush[:ensure] == :present
+      # create
+      action = 'create'
+      # because create doesn't reach get_resource_properties, set repo type and id here also
+      @pulp = Puppet::Util::PulpUtil.new
+      schedules =  @pulp.get_repo_syncs(resource[:name])
+      $schedules_info['repo_type'][resource[:name]] = schedules[1]
+      $schedules_info['repo_id'][resource[:name]] = resource[:name]
+    else
+      # update
+      params << ['--schedule-id', $schedules_info['repo_id'][resource[:name]]]
+      params << ['--enabled', resource[:enabled]] if !resource[:enabled].nil?
+      action = 'update'
+    end
+
+    case $schedules_info['repo_type'][repo_id]
+    when 'rpm-repo'
+      type = 'rpm'
+    when 'puppet-repo'
+      type = 'puppet'
+    when 'iso-repo'
+      type = 'iso'
+    else
+      raise "[set_schedule] Unknown repo type #{$schedules_info['repo_type'][repo_id]} for repo_id #{repo_id}"
+    end
+
+    arr = [type, 'repo', 'sync', 'schedules', action, '--repo-id', repo_id, params]
+    pulp_admin(arr.flatten)
+  end
+
+end

--- a/lib/puppet/type/pulp_schedule.rb
+++ b/lib/puppet/type/pulp_schedule.rb
@@ -1,0 +1,61 @@
+# curl -E ~/.pulp/user-cert.pem "https://$(hostname)/pulp/api/v2/repositories/optymyze_puppet_forge/importers/puppet_importer/schedules/sync/?details=True" | python -mjson.tool
+
+Puppet::Type.newtype(:pulp_schedule) do
+  @doc = <<-EOT
+    doc 
+  EOT
+
+  autorequire(:file) do
+    ['/etc/pulp/admin/admin.conf']
+  end
+
+  ensurable do
+    desc <<-EOS
+      Create/Remove pulp repo schedules.
+    EOS
+
+    newvalue(:present) do
+      provider.create
+    end
+
+    newvalue(:absent) do
+      provider.destroy
+    end
+
+    defaultto :present
+  end
+
+  newparam(:name, :namevar => true) do
+    desc "repo-id: uniquely identifies the rpm repo"
+  end
+
+  newproperty(:schedule_time) do
+    desc "time to execute in iso8601 format
+    (yyyy-mm-ddThh:mm:ssZ/PiuT); the number of
+    recurrences may be specified in this value"
+    isrequired
+  end
+
+  newproperty(:enabled, :boolean => true) do
+    desc 'if "false", the schedule will exist but will not trigger any executions'
+    newvalues(:true, :false)
+    defaultto :true
+
+    munge do |value|
+      case value
+      when true, "true", :true
+        :true
+      when false, "false", :false
+        :false
+      end
+    end
+  end
+
+  newproperty(:failure_threshold) do
+    desc "number of failures before the schedule is
+    automatically disabled; unspecified means the
+    schedule will never be automatically disabled"
+    newvalues(/^\d+$/)
+  end
+
+end

--- a/lib/puppet/util/pulp_util.rb
+++ b/lib/puppet/util/pulp_util.rb
@@ -1,0 +1,116 @@
+require 'net/http'
+require 'net/https'
+require 'openssl'
+require 'uri'
+require 'json'
+
+module Puppet
+  module Util
+    class PulpUtil
+      def initialize (config_path = '/etc/pulp/admin/admin.conf')
+        config               = parse_config(config_path)
+        @config              = {}
+        @config[:host]       = config['server']['host']                 || Facter['fqdn'].value
+        @config[:port]       = config['server']['port']                 || 443
+        @config[:api_prefix] = config['server']['api_prefix']           || "/pulp/api"
+        @config[:cert_dir]   = config['filesystem']['id_cert_dir']      || "~/.pulp"
+        @config[:cert_file]  = config['filesystem']['id_cert_filename'] || "user-cert.pem"
+      end
+
+      def get_repos()
+        request_api('', false)
+      end
+
+      def get_repo_syncs(repo_id)
+        # returns an array with 2 values: an array of sync schedules and the repo type
+        raise '[get_repo_syncs] Repo id should never be nil' if !repo_id or repo_id  == ''
+        info = request_api(repo_id, false)
+        return info if !info
+
+        # we need to see the repo type first
+        case info['notes']['_repo-type']
+        when 'rpm-repo'
+          importer = 'yum_importer'
+        when 'puppet-repo'
+          importer = 'puppet_importer'
+        when 'iso-repo'
+          importer = 'iso_importer'
+        else
+          print "[get_repo_syncs] Unknown repo type #{info['notes']['_repo-type']} for repo #{repo_id}.\n"
+          return [[], nil]
+        end
+        [request_api(repo_id, true, "/importers/#{importer}/schedules/sync/"), info['notes']['_repo-type']]
+      end
+
+      def get_repo_info(repo_id)
+        raise '[get_repo_info] Repo id should never be nil.' if !repo_id
+        request_api(repo_id, true)
+      end
+
+      private
+
+      def parse_config(path)
+        if File.file?(path)
+          settings = Hash.new
+          begin
+            file = File.new(path, "r")
+            while (line = file.gets)
+              if line =~ /(^#|^\s+$)/
+                # nada
+              elsif line =~ /^\[(.+)\]$/
+                section = $1
+                settings[section] = Hash.new
+              elsif line =~ /^[^\[]/
+                key, value = line.split(':')
+                settings[section][key] = value.strip
+              else
+                raise "I don't understand this line: #{line}"
+              end
+            end
+            file.close
+          rescue => err
+            puts "Exception: #{err}"
+          end
+
+          settings
+        end
+      end
+
+      def request_api(repo_id = nil, details = true, prefix = '')
+        begin
+          raise Puppet::Error, "[request_api] repo_id  can't be nil." if ! repo_id
+          details_url = details ? '?details=True' : ''
+          repo_url    = repo_id && !repo_id.empty? ? "#{repo_id}/"   : ''
+          url         = "https://#{@config[:host]}:#{@config[:port]}#{@config[:api_prefix]}/v2/repositories/#{repo_url}/#{prefix}/#{details_url}"
+
+          # when running from mco, home is not set
+          begin
+            cert_path = File.expand_path("#{@config[:cert_dir]}/#{@config[:cert_file]}")
+          rescue
+            cert_path = File.expand_path("/root/.pulp/#{@config[:cert_file]}")
+          end
+          uri = URI(url)
+          uri.path.squeeze!("/")
+          cert_raw = File.read(cert_path)
+
+          req = Net::HTTP::Get.new(uri.request_uri)
+          https = Net::HTTP.new(uri.host, uri.port)
+          https.use_ssl = true
+          https.cert = OpenSSL::X509::Certificate.new(cert_raw)
+          https.key = OpenSSL::PKey::RSA.new(cert_raw)
+          https.verify_mode = OpenSSL::SSL::VERIFY_PEER
+          #  https.ca_file = '/etc/pki/ca-trust/source/anchors/puppet_ca.pem'
+          resp = https.request req
+          if resp.code == '200'
+            JSON.parse(resp.body)
+          else
+            nil
+          end
+        rescue Exception => e
+          raise Puppet::Error, "https request for repo \"#{repo_id}\# threw exception #{e.message}. Connection details: url=#{url}, cert_path=#{cert_path}."
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Copied from previous PR:

This is an abomination because of some limiting factors: 
- I can't make the connection between repo id + schedule to a resource name
- I don't think that multiple schedules per repo can be implemented (from my point of view it can't be done)

Limitations:
- we can't have multiple schedules for the same repo, so we force the existence of only one schedule per repo (the one with the smallest sync_id). The resource name will be the repo_id
- user should not set the name of a repo to be the same as an existing schedule_id (probability is very small)
- if the repo (resource name) doesn't exists, the resource will fail (normal)
- there is a global variable used ($schedules_info)

Explanation on how it's implemented:
- when we get the resources, we set the resource name to repo_id only for the first schedule
- the other schedules get the name = schedule_id (this is useful only for purging)
- we need to keep somewhere the schedule_id for the first ones ($schedules_info['schedule_id']): this is needed in update
- we need to keep the repo_id for the second ones ($schedules_info['repo_id']): needed in delete, when we purge the resources
- since this provider is global for all repos, we need to keep the repo_type for all repos ($schedules_info['repo_type'])
- a special case is when we have a single resource defined in puppet with ensure => absent: we keep the schedule id in $schedules_info['repo_id']

Example usage:

```
pulp_schedule { 'scl_ruby22_el7':
  ensure        => 'present',
  enabled       => 'true',
  schedule_time => '2000-W01-6T12:00Z/P1W',
}

  pulp_schedule { 'katello_client_el7':
    ensure        => absent
  }
```

There is still a problem when purging repos and schedules: if the repo is deleted first, the schedule will fail to do the purging. I think this is because when deleting the repo, pulp cleans the schedules also.

I don't know how to fix this yet. I could to an extra check in delete to see if the schedule still exists, but it looks ugly. Also I don't like to add more special cases then there are already.
