### PR TITLE
python-gofer-qpid and python-gofer-amqp version

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,17 +4,11 @@ class pulp::install {
   package { ['pulp-server', 'pulp-selinux', 'python-pulp-streamer']: ensure => $pulp::version, }
 
   if $pulp::messaging_transport == 'qpid' {
-    ensure_packages(['python-gofer-qpid'], {
-      ensure => $pulp::version
-    }
-    )
+    ensure_packages(['python-gofer-qpid'])
   }
 
   if $pulp::messaging_transport == 'rabbitmq' {
-    ensure_packages(['python-gofer-amqp'], {
-      ensure => $pulp::version
-    }
-    )
+    ensure_packages(['python-gofer-amqp'])
   }
 
   if $pulp::enable_katello {


### PR DESCRIPTION
python-gofer-qpid and python-gofer-amqp are not yet available in the public repo in the same version than pulp
They seem to be in different versions