### PR TITLE
Messaging transport version

### DIFF
--- a/manifests/consumer.pp
+++ b/manifests/consumer.pp
@@ -88,6 +88,8 @@
 #
 # $messaging_transport::           The AMQP transport name. Valid options are 'qpid' or 'rabbitmq'. The default is 'qpid'.
 #
+# $messaging_version::             Determines the version of packages related to the 'messaging transport protocol'.
+#
 # $messaging_cacert::              The (optional) absolute path to a PEM encoded CA certificate to validate the identity of the
 #                                  broker.
 #

--- a/manifests/consumer.pp
+++ b/manifests/consumer.pp
@@ -138,6 +138,7 @@ class pulp::consumer (
   $messaging_host            = $pulp::consumer::params::messaging_host,
   $messaging_port            = $pulp::consumer::params::messaging_port,
   $messaging_transport       = $pulp::consumer::params::messaging_transport,
+  $messaging_version         = $pulp::consumer::params::messaging_version,
   $messaging_cacert          = $pulp::consumer::params::messaging_cacert,
   $messaging_clientcert      = $pulp::consumer::params::messaging_clientcert,
   $profile_minutes           = $pulp::consumer::params::profile_minutes,

--- a/manifests/consumer/install.pp
+++ b/manifests/consumer/install.pp
@@ -2,19 +2,23 @@
 class pulp::consumer::install {
   if $pulp::consumer::messaging_transport == 'qpid' {
     ensure_packages(['python-gofer-qpid'], {
-      ensure => $pulp::consumer::version
+      ensure => $pulp::consumer::messaging_version,
     }
     )
   }
 
   if $pulp::consumer::messaging_transport == 'rabbitmq' {
     ensure_packages(['python-gofer-amqp'], {
-      ensure => $pulp::consumer::version
+      ensure => $pulp::consumer::messaging_version,
     }
     )
   }
 
-  package { ['pulp-consumer-client', 'pulp-agent', 'gofer']:
+  package { 'gofer':
+    ensure => $pulp::consumer::messaging_version,
+  }
+
+  package { ['pulp-consumer-client', 'pulp-agent']:
     ensure => $pulp::consumer::version,
   }
 

--- a/manifests/consumer/params.pp
+++ b/manifests/consumer/params.pp
@@ -42,6 +42,7 @@ class pulp::consumer::params {
   $messaging_transport = 'qpid'
   $messaging_cacert = undef
   $messaging_clientcert = undef
+  $messaging_version = 'present'
 
   $profile_minutes = 240
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,6 +35,9 @@
 # $messaging_client_cert::      Absolute path to PEM encoded file containing both the private key and
 #                               certificate Pulp should present to the broker to be authenticated by the broker.
 #
+# $messaging_version::          Determines the version of packages related to the 'messaging transport protocol'.
+#
+#
 # $broker_url::                 A URL to a broker that Celery can use to queue tasks:
 #                               qpid://<username>:<password>@<hostname>:<port>/
 #
@@ -337,6 +340,7 @@ class pulp (
   $messaging_topic_exchange  = $pulp::params::messaging_topic_exchange,
   $messaging_event_notifications_enabled = $pulp::params::messaging_event_notifications_enabled,
   $messaging_event_notification_url = $pulp::params::messaging_event_notification_url,
+  $messaging_version         = $pulp::params::messaging_version,
   $broker_url                = $pulp::params::broker_url,
   $broker_use_ssl            = $pulp::params::broker_use_ssl,
   $tasks_login_method        = $pulp::params::tasks_login_method,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,14 +5,14 @@ class pulp::install {
 
   if $pulp::messaging_transport == 'qpid' {
     ensure_packages(['python-gofer-qpid'], {
-      ensure => $pulp::version
+      ensure => $pulp::messaging_version
     }
     )
   }
 
   if $pulp::messaging_transport == 'rabbitmq' {
     ensure_packages(['python-gofer-amqp'], {
-      ensure => $pulp::version
+      ensure => $pulp::messaging_version
     }
     )
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,14 +5,14 @@ class pulp::install {
 
   if $pulp::messaging_transport == 'qpid' {
     ensure_packages(['python-gofer-qpid'], {
-      ensure => $pulp::messaging_version
+      ensure => $pulp::messaging_version,
     }
     )
   }
 
   if $pulp::messaging_transport == 'rabbitmq' {
     ensure_packages(['python-gofer-amqp'], {
-      ensure => $pulp::messaging_version
+      ensure => $pulp::messaging_version,
     }
     )
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,6 +44,7 @@ class pulp::params {
   $messaging_topic_exchange = 'amq.topic'
   $messaging_event_notifications_enabled = false
   $messaging_event_notification_url = undef
+  $messaging_version = 'present'
 
   $broker_url = "qpid:///guest@${::fqdn}:5672"
   $broker_use_ssl = false


### PR DESCRIPTION
[messaging_transport_version]
    - new parameter 'messaging_transport_version'
    - it is related to the issue that when $version is set to e.g. 2.12.0-1.el7 it is also assigned
    to packages like 'python-gofer-qpid', 'python-gofer-amqp' or 'gofer' which do not have such number
    
     Changes to be committed:
    - modified:   manifests/init.pp
    - modified:   manifests/params.pp
    - modified:   manifests/install.pp
    - modified:   manifests/consumer.pp
    - modified:   manifests/consumer/install.pp
    - modified:   manifests/consumer/params.pp