### PR TITLE
Fixes #17219 - bump squid3 to 1.0.2

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -33,7 +33,7 @@
     },
     {
       "name": "thias/squid3",
-      "version_requirement": "1.0.0"
+      "version_requirement": "1.0.2"
     }
   ],
   "requirements": [


### PR DESCRIPTION
@ehelms in f461a2113dcd1aaa59fd2cd5d7cd461b20bad2f3 you pinned it to 1.0.0 - but I don't really see why the updates should break el6 - in any case if the problem persists put this off till el6 support is dropped from katello :D

Greetings
Klaas