### PR TITLE
broker service may not run on the same node

### DIFF
--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -20,8 +20,8 @@ class pulp::broker {
     }
   }
 
-  Service[$broker_service] -> Service['pulp_celerybeat']
-  Service[$broker_service] -> Service['pulp_workers']
-  Service[$broker_service] -> Service['pulp_resource_manager']
-  Service[$broker_service] -> Exec['migrate_pulp_db']
+  Service <| title == $broker_service |> -> Service['pulp_celerybeat']
+  Service <| title == $broker_service |> -> Service['pulp_workers']
+  Service <| title == $broker_service |> -> Service['pulp_resource_manager']
+  Service <| title == $broker_service |> -> Exec['migrate_pulp_db']
 }


### PR DESCRIPTION
When installing pulp and the message broker on different nodes, the
massage broker service is not present in the catalog and catalog
compilation fails.
Using a resource collector instead of referencing the service directly
makes the `Service[$broker_service]` optional.