### PR TITLE
Fix puppet-lint arrow_on_right_operand_line

### DIFF
--- a/manifests/admin.pp
+++ b/manifests/admin.pp
@@ -116,6 +116,6 @@ class pulp::admin (
   validate_bool($enable_color)
   validate_bool($wrap_to_terminal)
 
-  class { '::pulp::admin::install': } ~>
-  class { '::pulp::admin::config': }
+  class { '::pulp::admin::install': }
+  ~> class { '::pulp::admin::config': }
 }

--- a/manifests/child.pp
+++ b/manifests/child.pp
@@ -4,22 +4,22 @@
 # Install and configure Pulp node
 #
 class pulp::child (
-  $parent_fqdn           = undef,
-  $parent_qpid_scheme    = 'ssl',
-  $parent_qpid_port      = '5671',
-  $oauth_effective_user  = 'admin',
-  $oauth_key             = 'key',
-  $oauth_secret          = 'secret',
-  $ssl_cert              = '/etc/pki/pulp/ssl_apache.crt',
-  $ssl_key               = '/etc/pki/pulp/ssl_apache.key',
-  $server_ca_cert        = '/etc/pki/pulp/ca.crt'
+  $parent_fqdn          = undef,
+  $parent_qpid_scheme   = 'ssl',
+  $parent_qpid_port     = '5671',
+  $oauth_effective_user = 'admin',
+  $oauth_key            = 'key',
+  $oauth_secret         = 'secret',
+  $ssl_cert             = '/etc/pki/pulp/ssl_apache.crt',
+  $ssl_key              = '/etc/pki/pulp/ssl_apache.key',
+  $server_ca_cert       = '/etc/pki/pulp/ca.crt'
 ) {
 
   unless $parent_fqdn {
     fail('$parent_fqdn has to be specified')
   }
 
-  class { '::pulp::child::install': } ~>
-  class { '::pulp::child::config': } ~>
-  class { '::pulp::child::service': }
+  class { '::pulp::child::install': }
+  ~> class { '::pulp::child::config': }
+  ~> class { '::pulp::child::service': }
 }

--- a/manifests/consumer.pp
+++ b/manifests/consumer.pp
@@ -154,7 +154,7 @@ class pulp::consumer (
   validate_bool($enable_color)
   validate_bool($wrap_to_terminal)
 
-  class { '::pulp::consumer::install': } ->
-  class { '::pulp::consumer::config': } ~>
-  class { '::pulp::consumer::service': }
+  class { '::pulp::consumer::install': }
+  -> class { '::pulp::consumer::config': }
+  ~> class { '::pulp::consumer::service': }
 }

--- a/manifests/crane.pp
+++ b/manifests/crane.pp
@@ -35,8 +35,8 @@ class pulp::crane (
   validate_integer($port)
   validate_integer($data_dir_polling_interval)
 
-  class { '::pulp::crane::install': } ~>
-  class { '::pulp::crane::config': } ~>
-  class { '::pulp::crane::apache': } ->
-  Class['pulp::crane']
+  class { '::pulp::crane::install': }
+  ~> class { '::pulp::crane::config': }
+  ~> class { '::pulp::crane::apache': }
+  -> Class['pulp::crane']
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -469,9 +469,9 @@ class pulp (
     }
   }
 
-  class { '::pulp::install': } ->
-  class { '::pulp::config': } ~>
-  class { '::pulp::service': } ->
-  Class[pulp] ~>
-  Service['httpd']
+  class { '::pulp::install': }
+  -> class { '::pulp::config': }
+  ~> class { '::pulp::service': }
+  -> Class['pulp']
+  ~> Service['httpd']
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -3,8 +3,8 @@ class pulp::service {
   exec { 'pulp refresh system service':
     command     => '/bin/systemctl daemon-reload',
     refreshonly => true,
-  } ->
-  service { ['pulp_celerybeat', 'pulp_workers', 'pulp_resource_manager', 'pulp_streamer']:
+  }
+  -> service { ['pulp_celerybeat', 'pulp_workers', 'pulp_resource_manager', 'pulp_streamer']:
     ensure => running,
     enable => true,
   }


### PR DESCRIPTION
This check was added in puppet-lint 2.2.0.
https://github.com/rodjek/puppet-lint/pull/672
https://docs.puppet.com/puppet/latest/style_guide.html#chaining-arrow-syntax