### PR TITLE
Include mod_proxy_http apache module

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -2,6 +2,7 @@
 class pulp::apache {
   include ::apache
   include ::apache::mod::proxy
+  include ::apache::mod::proxy_http
   include ::apache::mod::wsgi
   include ::apache::mod::ssl
   include ::apache::mod::xsendfile

--- a/spec/classes/pulp_apache_spec.rb
+++ b/spec/classes/pulp_apache_spec.rb
@@ -16,6 +16,8 @@ describe 'pulp::apache' do
 
     it 'should include apache with modules' do
       is_expected.to contain_class('apache')
+      is_expected.to contain_class('apache::mod::proxy')
+      is_expected.to contain_class('apache::mod::proxy_http')
       is_expected.to contain_class('apache::mod::wsgi')
       is_expected.to contain_class('apache::mod::ssl')
     end


### PR DESCRIPTION
Pulp streamer requires mod_proxy_http module as well as mod_proxy.

Otherwise, you get errors like these...
```
AH01144: No protocol handler was valid for the URL
/streamer/var/lib/pulp/content/units/rpm/a6/ee6dc94611e32292032077fb753b71fefb36b7ae550d16d11f17d65999a4f7/bind-utils-9.9.4-38.el7_3.2.x86_64.rpm.
If you are using a DSO version of mod_proxy, make sure the proxy
submodules are included in the configuration using LoadModule.
```