### PR TITLE
Use concat 2.2.1 in .fixtures

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,7 +5,9 @@ fixtures:
       repo: 'git://github.com/puppet-community/puppet-extlib'
       ref:  'v0.11.3'
     apache:  "git://github.com/puppetlabs/puppetlabs-apache.git"
-    concat:  "git://github.com/puppetlabs/puppetlabs-concat.git"
+    concat:
+      repo: 'git://github.com/puppetlabs/puppetlabs-concat.git'
+      ref:  '2.2.1'
     mongodb: "git://github.com/puppetlabs/puppetlabs-mongodb.git"
     qpid:    "git://github.com/katello/puppet-qpid.git"
     squid3:  "git://github.com/thias/puppet-squid3.git"


### PR DESCRIPTION
concat master has just dropped support for puppet 3.  2.2.1 was made a
few days earlier.  Presumably this will be the last release to support
puppet 3 and the next release of concat will be 3.0.0.