### PR TITLE
Add pulp_rpmbind type

### DIFF
--- a/lib/puppet/provider/pulp_rpmbind/consumer.rb
+++ b/lib/puppet/provider/pulp_rpmbind/consumer.rb
@@ -1,0 +1,57 @@
+require 'pathname'
+
+Puppet::Type.type(:pulp_rpmbind).provide(:consumer) do
+  desc 'Bind/unbind to an RPM repo'
+
+  confine osfamily: :redhat
+  commands consumer: '/bin/pulp-consumer'
+  commands grep:     '/bin/grep'
+
+  def self.repo_file
+    default = '/etc/yum.repos.d/pulp.repo'
+    begin
+      repo_file = grep('-oP', '^repo_file:\s+\K.*', '/etc/pulp/consumer/consumer.conf')
+      repo_file.strip!
+    rescue Puppet::ExecutionFailure => e
+      Puppet.debug "Couldn't find repo_file configuration in /etc/pulp/consumer/consumer.conf -> #{e.inspect}"
+      return default
+    end
+    return repo_file if (Pathname.new repo_file).absolute?
+    Puppet.debug "repo_file #{repo_file} is not an absolute path.  Using default"
+    default
+  end
+
+  def self.instances
+    begin
+      binds = grep('-oP', '^\[\K.*(?=\]$)', repo_file)
+    rescue Puppet::ExecutionFailure => e
+      Puppet.debug "grepping for binds had an error -> #{e.inspect}"
+      return {}
+    end
+    binds.split("\n").collect do |line|
+      new(name: line, ensure: :present)
+    end
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if (resource = resources[prov.name])
+        resource.provider = prov
+      end
+    end
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    consumer('rpm', 'bind', '--repo-id', @resource[:name])
+    @property_hash[:ensure] = :present
+  end
+
+  def destroy
+    consumer('rpm', 'unbind', '--repo-id', @resource[:name])
+    @property_hash[:ensure] = :absent
+  end
+end

--- a/lib/puppet/type/pulp_rpmbind.rb
+++ b/lib/puppet/type/pulp_rpmbind.rb
@@ -1,0 +1,13 @@
+Puppet::Type.newtype(:pulp_rpmbind) do
+  ensurable do
+    desc 'Bind/unbind to an RPM repo'
+
+    defaultvalues
+    defaultto :present
+  end
+
+  newparam(:repo_id) do
+    desc 'The repo-id'
+    isnamevar
+  end
+end

--- a/spec/unit/puppet/type/pulp_rpmbind_spec.rb
+++ b/spec/unit/puppet/type/pulp_rpmbind_spec.rb
@@ -1,0 +1,29 @@
+require 'puppet'
+require 'puppet/type/pulp_rpmbind'
+
+describe Puppet::Type.type(:pulp_rpmbind) do
+  describe 'namevar' do
+    it 'has repo_id as its namevar' do
+      expect(described_class.key_attributes).to eq([:repo_id])
+    end
+  end
+
+  describe 'ensure' do
+    %i[present absent].each do |value|
+      it "suppports #{value} as a value to :ensure" do
+        expect { described_class.new(repo_id: 'test-repo', ensure: value) }
+          .not_to raise_error
+      end
+    end
+
+    it 'rejects other values' do
+      expect { described_class.new(repo_id: 'test-repo', ensure: 'foo') }
+        .to raise_error(Puppet::Error)
+    end
+
+    it 'defaults to present' do
+      expect(described_class.new(repo_id: 'test-repo').should(:ensure))
+        .to eq(:present)
+    end
+  end
+end


### PR DESCRIPTION
To be used on agent (pulp-consumer) nodes to (un)bind to RPM repos.

fixes #GH-230