### PR TITLE
Add pulp_consumer_id fact

### DIFF
--- a/lib/facter/pulp_consumer_id.rb
+++ b/lib/facter/pulp_consumer_id.rb
@@ -1,0 +1,8 @@
+require 'facter/util/pulp'
+
+Facter.add(:pulp_consumer_id) do
+  confine kernel: 'Linux'
+  setcode do
+    Facter::Util::Pulp.pulp_consumer_id
+  end
+end

--- a/lib/facter/pulp_consumer_server.rb
+++ b/lib/facter/pulp_consumer_server.rb
@@ -1,0 +1,8 @@
+require 'facter/util/pulp'
+
+Facter.add(:pulp_consumer_server) do
+  confine kernel: 'Linux'
+  setcode do
+    Facter::Util::Pulp.pulp_consumer_server
+  end
+end

--- a/lib/facter/util/pulp.rb
+++ b/lib/facter/util/pulp.rb
@@ -1,0 +1,19 @@
+module Facter::Util::Pulp
+  def self.consumer_status_matchdata
+    status = Facter::Util::Resolution.exec('pulp-consumer status')
+    return nil if status.nil?
+    # Strip color from command output
+    status.gsub!(/\e\[([;\d]+)?m/, '')
+    /^This consumer is registered to the server\s\[(?<server_id>.*)\]\swith\sthe\sID\s\[(?<consumer_id>.*)\]\.$/.match(status)
+  end
+
+  def self.pulp_consumer_id
+    matchdata = consumer_status_matchdata
+    matchdata[:consumer_id] unless matchdata.nil?
+  end
+
+  def self.pulp_consumer_server
+    matchdata = consumer_status_matchdata
+    matchdata[:server_id] unless matchdata.nil?
+  end
+end


### PR DESCRIPTION
It's useful to know if you're already registered with a pulp server.
If not, (as well as including pulp::consumer and using pulp_register),
I want to be able to declare a yumrepo resource for a repo containing
pulp packages.  On the next puppet run, (host is registered), I can
then declare the same resource with ensure => absent and start using
pulp binds instead.