### PR TITLE
Add basic provider for Pulp roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,14 @@ class { '::pulp':
 }
 ```
 
+### Role provider
+
+	pulp_role { 'repo_admin':
+	  ensure      => 'present',
+	  users       => ['alice', 'bob'],
+	  permissions => {'/' => ['READ', 'CREATE'], '/pulp/api/v2/repositories/scl_ruby22_el7/' => ['READ', 'EXECUTE', 'UPDATE', 'CREATE', 'DELETE']},
+	}
+
 ## Development
 
 See the CONTRIBUTING guide for steps on how to make a change and get it accepted upstream.

--- a/examples/pulp_role.pp
+++ b/examples/pulp_role.pp
@@ -1,0 +1,15 @@
+class { '::pulp::repo::upstream': } ->
+class { '::pulp':
+  # https://github.com/Katello/puppet-pulp/issues/138
+  ssl_username => '',
+  enable_admin => true,
+}
+
+pulp_role { 'myrepo_admins':
+  users       => ['alice', 'bob'],
+  permissions => {
+                   '/'                        => ['READ','EXECUTE'],
+                   '/v2/repositories/myrepo/' => ['CREATE','READ','DELETE','EXECUTE','UPDATE']
+                 },
+  ensure      => 'present',
+}

--- a/examples/pulp_role.pp
+++ b/examples/pulp_role.pp
@@ -6,10 +6,10 @@ class { '::pulp':
 }
 
 pulp_role { 'myrepo_admins':
+  ensure      => 'present',
   users       => ['alice', 'bob'],
   permissions => {
-                   '/'                        => ['READ','EXECUTE'],
-                   '/v2/repositories/myrepo/' => ['CREATE','READ','DELETE','EXECUTE','UPDATE']
-                 },
-  ensure      => 'present',
+    '/'                        => ['READ','EXECUTE'],
+    '/v2/repositories/myrepo/' => ['CREATE','READ','DELETE','EXECUTE','UPDATE'],
+  },
 }

--- a/lib/puppet/provider/pulp_role/api.rb
+++ b/lib/puppet/provider/pulp_role/api.rb
@@ -1,0 +1,113 @@
+
+require File.expand_path('../../../util/pulp_util', __FILE__)
+
+Puppet::Type.type(:pulp_role).provide(:api) do
+  commands :pulp_admin => '/usr/bin/pulp-admin'
+
+  mk_resource_methods
+
+  def initialize(resource={})
+    super(resource)
+    @pulp = Puppet::Util::PulpUtil.new
+  end
+
+  def exists?
+    r = @pulp.get_role_info(name())
+    !r.nil?()
+  end
+
+  def create
+    manage_role('create', name())
+  end
+
+  def destroy
+    manage_role('delete', name())
+  end
+
+  def users
+    users = @pulp.get_role_users(name())
+    if users.nil?
+      nil
+    end
+
+    @users = users
+    @users
+  end
+
+  def users=(should)
+    users_to_add = should - @users
+    users_to_rm = @users - should
+    users_to_add.each() do |user|
+      if user_exist(user)
+        role_user_mod("add", user, name())
+      else
+        Puppet::Util::Warnings.warnonce("#{user} does not exist in Pulp, can't be added to any role")
+      end
+    end
+    users_to_rm.each() do |user|
+      role_user_mod("remove", user, name())
+    end
+  end
+
+  def permissions
+    permissions = @pulp.get_role_permissions(name())
+    if permissions.nil?
+      nil
+    end
+
+    @permissions = permissions
+    @permissions
+  end
+
+  def permissions=(should)
+    should.each_key() do |k|
+      # if key is already there, inspect each permission associated
+      if @permissions.has_key?(k)
+        if should[k] != @permissions[k]
+          perms_to_add = should[k] - @permissions[k]
+          perms_to_add.each() do |perm|
+            role_permission_mod("grant", k, perm, name())
+          end
+
+          perms_to_remove = @permissions[k] - should[k]
+          perms_to_remove.each() do |perm|
+            role_permission_mod("revoke", k, perm, name())
+          end
+        end
+      # if key is absent, add all permissions
+      else
+        should[k].each() do |perm|
+          role_permission_mod("grant", k, perm, name())
+        end
+      end
+    end
+
+    # Remove a key which should not be there anymore
+    @permissions.each_key() do |k|
+      if ! should.has_key?(k)
+        @permissions[k].each() do |perm|
+          role_permission_mod("revoke", k, perm, name())
+        end
+      end
+    end
+
+  end
+
+  def user_exist(login)
+    stdout = pulp_admin(['auth', 'user', 'search', '--str-eq', 'login='+login])
+    return true if stdout.to_s =~ /Login:/
+  end
+
+  def manage_role(action, role_id)
+    pulp_admin(['auth', 'role', action, '--role-id', role_id])
+  end
+
+  def role_user_mod(action, user, role_id)
+    pulp_admin(['auth', 'role', 'user', action, '--role-id', role_id, '--login', user])
+  end
+
+  def role_permission_mod(action, resource, permission, role_id)
+    pulp_admin(['auth', 'permission', action, '--role-id', role_id, '--resource', resource, '-o', permission])
+  end
+
+end

--- a/lib/puppet/provider/pulp_role/api.rb
+++ b/lib/puppet/provider/pulp_role/api.rb
@@ -26,9 +26,6 @@ Puppet::Type.type(:pulp_role).provide(:api) do
 
   def users
     users = @pulp.get_role_users(name())
-    if users.nil?
-      nil
-    end
 
     @users = users
     @users
@@ -51,9 +48,6 @@ Puppet::Type.type(:pulp_role).provide(:api) do
 
   def permissions
     permissions = @pulp.get_role_permissions(name())
-    if permissions.nil?
-      nil
-    end
 
     @permissions = permissions
     @permissions

--- a/lib/puppet/provider/pulp_role/api.rb
+++ b/lib/puppet/provider/pulp_role/api.rb
@@ -84,7 +84,7 @@ Puppet::Type.type(:pulp_role).provide(:api) do
 
     # Remove a key which should not be there anymore
     @permissions.each_key() do |k|
-      if ! should.has_key?(k)
+      unless should.has_key?(k)
         @permissions[k].each() do |perm|
           role_permission_mod("revoke", k, perm, name())
         end

--- a/lib/puppet/type/pulp_role.rb
+++ b/lib/puppet/type/pulp_role.rb
@@ -1,0 +1,28 @@
+
+Puppet::Type.newtype(:pulp_role) do
+  @doc = <<-EOT
+    doc
+  EOT
+
+  autorequire(:file) do
+    ['/etc/pulp/admin/admin.conf']
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  newparam(:name, :namevar => true) do
+    desc "role-id: uniquely identifies the role"
+  end
+
+  newproperty(:users, :array_matching => :all) do
+    desc "users to add to this role"
+  end
+
+  newproperty(:permissions) do
+    desc "resources/permissions to grant to this role"
+  end
+
+end

--- a/lib/puppet/util/pulp_util.rb
+++ b/lib/puppet/util/pulp_util.rb
@@ -50,6 +50,23 @@ module Puppet
         request_api("/v2/repositories/#{repo_id}/?details=True")
       end
 
+      def get_role_info(role_id)
+        raise '[get_role_info] Role id should never be nil.' if !role_id
+        request_api("/v2/roles/#{role_id}/")
+      end
+
+      def get_role_users(role_id)
+        raise '[get_role_users] Role id should never be nil.' if !role_id
+        r = get_role_info(role_id)
+        r['users']
+      end
+
+      def get_role_permissions(role_id)
+        raise '[get_role_users] Role id should never be nil.' if !role_id
+        r = get_role_info(role_id)
+        r['permissions']
+      end
+
       private
 
       def parse_config(path)

--- a/lib/puppet/util/pulp_util.rb
+++ b/lib/puppet/util/pulp_util.rb
@@ -51,18 +51,18 @@ module Puppet
       end
 
       def get_role_info(role_id)
-        raise '[get_role_info] Role id should never be nil.' if !role_id
+        raise '[get_role_info] Role id should never be nil.' unless role_id
         request_api("/v2/roles/#{role_id}/")
       end
 
       def get_role_users(role_id)
-        raise '[get_role_users] Role id should never be nil.' if !role_id
+        raise '[get_role_users] Role id should never be nil.' unless role_id
         r = get_role_info(role_id)
         r['users']
       end
 
       def get_role_permissions(role_id)
-        raise '[get_role_users] Role id should never be nil.' if !role_id
+        raise '[get_role_users] Role id should never be nil.' unless role_id
         r = get_role_info(role_id)
         r['permissions']
       end


### PR DESCRIPTION
Thanks to crfistifalcas various providers and the help of riton, here is a provider for Pulp roles.

It adds/removes roles, ensures the desired users are members of it and manages hashes representing URLs and associated permissions. It does not manage the "display name" and "description" attributes, though.