### PR TITLE
Use the $pulp::ca_cert variable rather than hardcoding

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -122,7 +122,8 @@ class pulp::config {
 
   exec { 'run pulp-gen-ca':
     command => '/usr/bin/pulp-gen-ca-certificate',
-    creates => '/etc/pki/pulp/ca.crt',
+    creates => $::pulp::ca_cert,
+    require => File['/etc/pulp/server.conf'],
   }
 
   if $pulp::manage_squid {


### PR DESCRIPTION
The pulp-gen-ca-certificate reads the location from the config file, so
the output location is variable.