### PR TITLE
Run pulp-gen-key-pair to create the rsa key

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -97,6 +97,9 @@ class pulp::config {
     mode    => '0644',
   }
 
+  exec { '/usr/bin/pulp-gen-key-pair':
+    creates => $::pulp::rsa_key,
+  } ->
   file { $::pulp::rsa_key:
     owner => 'root',
     group => 'apache',


### PR DESCRIPTION
https://github.com/pulp/pulp/commit/7476b6cb6971ff5a513152b698fb7b861dcc42a0 removed the generation of the RSA keypair from the post installation. Since 2.13.0 is pulled in nightly, this is causing problems.

This will fail on older pulp versions since they don't ship this script, but the file should be present due to to a %post script. The module also had no way of dealing with this file missing.

This relates to https://github.com/Katello/puppet-pulp/pull/182 where it was decided not to implement it in the module..