### PR TITLE
Fix typo in apache manifest

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -53,7 +53,7 @@ class pulp::apache {
         $base_directories,
         {
           'path'            => '/pulp/api',
-          'provider'        => 'Location',
+          'provider'        => 'location',
           'custom_fragment' => "SSLUsername ${::pulp::ssl_username}",
         }
       )


### PR DESCRIPTION
The capital L in location is actually causing apache to use
a Directory block instead of a Location one. This block is
being ignored because /pulp/api doesn't exist on the
filesystem.