### PR TITLE
Fixes GH-243 - Ruby 1.8 compatible syntax for facts

### DIFF
--- a/lib/facter/pulp_consumer_id.rb
+++ b/lib/facter/pulp_consumer_id.rb
@@ -1,7 +1,7 @@
 require 'facter/util/pulp'
 
 Facter.add(:pulp_consumer_id) do
-  confine kernel: 'Linux'
+  confine :kernel => 'Linux'
   setcode do
     Facter::Util::Pulp.pulp_consumer_id
   end

--- a/lib/facter/pulp_consumer_server.rb
+++ b/lib/facter/pulp_consumer_server.rb
@@ -1,7 +1,7 @@
 require 'facter/util/pulp'
 
 Facter.add(:pulp_consumer_server) do
-  confine kernel: 'Linux'
+  confine :kernel => 'Linux'
   setcode do
     Facter::Util::Pulp.pulp_consumer_server
   end

--- a/lib/facter/util/pulp.rb
+++ b/lib/facter/util/pulp.rb
@@ -4,7 +4,8 @@ module Facter::Util::Pulp
     return nil if status.nil?
     # Strip color from command output
     status.gsub!(/\e\[([;\d]+)?m/, '')
-    /^This consumer is registered to the server\s\[(?<server_id>.*)\]\swith\sthe\sID\s\[(?<consumer_id>.*)\]\.$/.match(status)
+    /^This consumer is registered to the server\s\[(.*)\]\swith\sthe\sID\s\[(.*)\]\.$/.match(status)
+    result = {:server_id => $1, :consumer_id => $2}
   end
 
   def self.pulp_consumer_id


### PR DESCRIPTION
These are just syntax changes to maintain facts compatibility with Ruby 1.8.7.
These changes aim at allowing EL6 systems to share the same Puppet environment as Pulp servers, without breaking facts collection on EL6.