### PR TITLE
pulp-admin refactoring

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,4 +1,7 @@
 ---
+.travis.yml:
+  beaker_sets:
+    - docker/centos-7
 Rakefile:
   param_docs_pattern:
     - manifests/admin.pp

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,13 @@ env:
   - PUPPET_VERSION=4.6 ONLY_OS=redhat-7-x86_64,centos-7-x86_64
 matrix:
   fast_finish: true
+  include:
+    # Acceptance tests
+    - rvm: 2.3.1
+      dist: trusty
+      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/centos-7
+      script: bundle exec rake beaker
+      services: docker
+      bundler_args: --without development
 bundler_args: --without system_tests development
 sudo: false

--- a/manifests/admin.pp
+++ b/manifests/admin.pp
@@ -63,6 +63,10 @@
 #
 # $puppet_upload_chunk_size::      Maximum amount of data (in bytes) sent for an upload in a single request
 #
+# $username::                      The username to login with
+#
+# $password::                      The password to login with. If left undefined then no login will be performed.
+#
 class pulp::admin (
   String $version = $::pulp::admin::params::version,
   String $host = $::pulp::admin::params::host,
@@ -90,9 +94,12 @@ class pulp::admin (
   Boolean $enable_rpm = $::pulp::admin::params::enable_rpm,
   String $puppet_upload_working_dir = $::pulp::admin::params::puppet_upload_working_dir,
   Integer[0] $puppet_upload_chunk_size = $::pulp::admin::params::puppet_upload_chunk_size,
+  String $username = $::pulp::admin::params::username,
+  Optional[String] $password = $::pulp::admin::params::username,
 ) inherits pulp::admin::params {
   contain ::pulp::admin::install
   contain ::pulp::admin::config
+  contain ::pulp::admin::login
 
-  Class['pulp::admin::install'] -> Class['pulp::admin::config']
+  Class['pulp::admin::install'] -> Class['pulp::admin::config'] -> Class['pulp::admin::login']
 }

--- a/manifests/admin.pp
+++ b/manifests/admin.pp
@@ -63,6 +63,8 @@
 #
 # $puppet_upload_chunk_size::      Maximum amount of data (in bytes) sent for an upload in a single request
 #
+# $login_method::                  The method to ensure root can use pulp-admin. Choose none to disable this behaviour.
+#
 # $username::                      The username to login with
 #
 # $password::                      The password to login with. If left undefined then no login will be performed.
@@ -94,9 +96,14 @@ class pulp::admin (
   Boolean $enable_rpm = $::pulp::admin::params::enable_rpm,
   String $puppet_upload_working_dir = $::pulp::admin::params::puppet_upload_working_dir,
   Integer[0] $puppet_upload_chunk_size = $::pulp::admin::params::puppet_upload_chunk_size,
+  Enum['none', 'file', 'login'] $login_method = $::pulp::admin::params::login_method,
   String $username = $::pulp::admin::params::username,
   Optional[String] $password = $::pulp::admin::params::username,
 ) inherits pulp::admin::params {
+  if $login_method != 'none' {
+    assert_type(String, $password)
+  }
+
   contain ::pulp::admin::install
   contain ::pulp::admin::config
   contain ::pulp::admin::login

--- a/manifests/admin.pp
+++ b/manifests/admin.pp
@@ -91,6 +91,8 @@ class pulp::admin (
   String $puppet_upload_working_dir = $::pulp::admin::params::puppet_upload_working_dir,
   Integer[0] $puppet_upload_chunk_size = $::pulp::admin::params::puppet_upload_chunk_size,
 ) inherits pulp::admin::params {
-  class { '::pulp::admin::install': } ~>
-  class { '::pulp::admin::config': }
+  contain ::pulp::admin::install
+  contain ::pulp::admin::config
+
+  Class['pulp::admin::install'] -> Class['pulp::admin::config']
 }

--- a/manifests/admin/login.pp
+++ b/manifests/admin/login.pp
@@ -1,0 +1,12 @@
+class pulp::admin::login (
+  $username = $::pulp::admin::username,
+  $password = $::pulp::admin::password,
+  $id_cert_filename = $::pulp::admin::id_cert_filename,
+) {
+  if $password and $password != '' {
+    exec { 'pulp-auth':
+      command => "/usr/bin/pulp-admin login -u '${username}' -p '${password}'",
+      creates => "/root/.pulp/${id_cert_filename}",
+    }
+  }
+}

--- a/manifests/admin/login.pp
+++ b/manifests/admin/login.pp
@@ -1,12 +1,33 @@
 class pulp::admin::login (
+  $login_method = $::pulp::admin::login_method,
   $username = $::pulp::admin::username,
   $password = $::pulp::admin::password,
   $id_cert_filename = $::pulp::admin::id_cert_filename,
 ) {
-  if $password and $password != '' {
-    exec { 'pulp-auth':
-      command => "/usr/bin/pulp-admin login -u '${username}' -p '${password}'",
-      creates => "/root/.pulp/${id_cert_filename}",
+  file { '/root/.pulp':
+    ensure => directory,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0700',
+  }
+
+  case $login_method {
+    'file': {
+      file { '/root/.pulp/admin.conf':
+        ensure  => file,
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0600',
+        content => template('pulp/admin_home.conf.erb'),
+      }
     }
+    'login': {
+      exec { 'pulp-auth':
+        command => "/usr/bin/pulp-admin login -u '${username}' -p '${password}'",
+        creates => "/root/.pulp/${id_cert_filename}",
+        require => File['/root/.pulp'],
+      }
+    }
+    default: {}
   }
 }

--- a/manifests/admin/params.pp
+++ b/manifests/admin/params.pp
@@ -28,6 +28,7 @@ class pulp::admin::params {
   $puppet_upload_working_dir = '~/.pulp/puppet-uploads'
   $puppet_upload_chunk_size  = 1048576
 
+  $login_method = 'none'
   $username = 'admin'
   $password = undef
 }

--- a/manifests/admin/params.pp
+++ b/manifests/admin/params.pp
@@ -27,4 +27,7 @@ class pulp::admin::params {
 
   $puppet_upload_working_dir = '~/.pulp/puppet-uploads'
   $puppet_upload_chunk_size  = 1048576
+
+  $username = 'admin'
+  $password = undef
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -188,6 +188,8 @@
 #
 # $num_workers::                Number of Pulp workers to use.
 #
+# $enable_admin::               Whether to install and configure the admin command
+#
 # $enable_katello::             Whether to enable pulp katello plugin.
 #
 # $enable_crane::               Whether to enable crane docker repository
@@ -327,6 +329,7 @@ class pulp (
   Optional[String] $proxy_password = $::pulp::params::proxy_password,
   Optional[String] $yum_max_speed = $::pulp::params::yum_max_speed,
   Integer[0] $num_workers = $::pulp::params::num_workers,
+  Boolean $enable_admin = $::pulp::params::enable_admin,
   Boolean $enable_katello = $::pulp::params::enable_katello,
   Boolean $enable_crane = $::pulp::params::enable_crane,
   Optional[Integer[0]] $max_tasks_per_child = $::pulp::params::max_tasks_per_child,
@@ -392,4 +395,19 @@ class pulp (
   contain ::pulp::apache
 
   Class['pulp::install'] -> Class['pulp::config'] -> Class['pulp::database'] ~> Class['pulp::service', 'pulp::apache']
+
+  if $enable_admin {
+    class { '::pulp::admin':
+      enable_docker => $enable_docker,
+      enable_nodes  => $enable_parent_node,
+      enable_ostree => $enable_ostree,
+      enable_puppet => $enable_puppet,
+      enable_python => $enable_python,
+      enable_rpm    => $enable_rpm,
+      ca_path       => $ca_cert,
+      username      => $default_login,
+      password      => $default_password,
+      require       => Class['pulp::apache'],
+    }
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -397,6 +397,13 @@ class pulp (
   Class['pulp::install'] -> Class['pulp::config'] -> Class['pulp::database'] ~> Class['pulp::service', 'pulp::apache']
 
   if $enable_admin {
+    if $ssl_username and $ssl_username != '' {
+      warning('Using $ssl_username means pulp-admin login doesn\'t work. Falling back to file login but pulp_*repo providers won\'t work')
+      $login_method = 'file'
+    } else {
+      $login_method = 'login'
+    }
+
     class { '::pulp::admin':
       enable_docker => $enable_docker,
       enable_nodes  => $enable_parent_node,
@@ -405,6 +412,7 @@ class pulp (
       enable_python => $enable_python,
       enable_rpm    => $enable_rpm,
       ca_path       => $ca_cert,
+      login_method  => $login_method,
       username      => $default_login,
       password      => $default_password,
       require       => Class['pulp::apache'],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -64,6 +64,7 @@ class pulp::params {
   $crane_port = 5000
   $crane_data_dir = '/var/lib/pulp/published/docker/v2/app'
 
+  $enable_admin = false
   $enable_katello = false
   $enable_crane = false
   $enable_rpm = true

--- a/spec/acceptance/admin_spec.rb
+++ b/spec/acceptance/admin_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper_acceptance'
+
+describe 'Scenario: pulp-admin' do
+  let(:pp) do
+    <<-EOS
+    class { '::pulp::repo::upstream': } ->
+    class { '::pulp':
+      # https://github.com/Katello/puppet-pulp/issues/138
+      ssl_username => '',
+      enable_admin => true,
+    }
+    pulp_rpmrepo { 'Zoo':
+      feed => 'https://repos.fedorapeople.org/repos/pulp/pulp/demo_repos/zoo/',
+    }
+    pulp_isorepo { 'DataMonster':
+    }
+    EOS
+  end
+
+  it_behaves_like 'a idempotent resource'
+
+  describe package('pulp-admin-client') do
+    it { is_expected.to be_installed }
+  end
+
+  describe command('pulp-admin status') do
+    its(:exit_status) { is_expected.to eq 0 }
+  end
+
+  describe command('pulp-admin repo list') do
+    its(:exit_status) { is_expected.to eq 0 }
+    its(:stdout) { is_expected.to include 'Zoo' }
+    its(:stdout) { is_expected.to include 'DataMonster' }
+  end
+end

--- a/spec/acceptance/nodesets/docker/centos-6.yml
+++ b/spec/acceptance/nodesets/docker/centos-6.yml
@@ -3,7 +3,7 @@
 # https://github.com/voxpupuli/modulesync
 # https://github.com/Katello/foreman-installer-modulesync
 HOSTS:
-  centos-6-x64:
+  centos-6-x64.example.com:
     platform: el-6-x86_64
     hypervisor: docker
     image: centos:6

--- a/spec/acceptance/nodesets/docker/centos-7.yml
+++ b/spec/acceptance/nodesets/docker/centos-7.yml
@@ -3,7 +3,7 @@
 # https://github.com/voxpupuli/modulesync
 # https://github.com/Katello/foreman-installer-modulesync
 HOSTS:
-  centos-7-x64:
+  centos-7-x64.example.com:
     platform: el-7-x86_64
     hypervisor: docker
     image: centos:7

--- a/spec/acceptance/pulp_spec.rb
+++ b/spec/acceptance/pulp_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper_acceptance'
+
+describe 'Scenario: install pulp' do
+  let(:pp) do
+    <<-EOS
+    class { '::pulp::repo::upstream': } ->
+    class { '::pulp': }
+    EOS
+  end
+
+  it_behaves_like 'a idempotent resource'
+
+  ['httpd', 'mongod', 'pulp_celerybeat', 'pulp_workers', 'pulp_resource_manager', 'pulp_streamer'].each do |service_name|
+    describe service(service_name) do
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
+    end
+  end
+
+  describe port(80) do
+    it { is_expected.to be_listening }
+  end
+
+  describe port(443) do
+    it { is_expected.to be_listening }
+  end
+end

--- a/spec/classes/pulp_admin_login_spec.rb
+++ b/spec/classes/pulp_admin_login_spec.rb
@@ -1,31 +1,59 @@
 require 'spec_helper'
 
 describe 'pulp::admin::login' do
-  context 'with an undefined password' do
+  context 'with login_method none' do
     let :params do
       {
-        'username'         => 'admin',
-        'password'         => '',
-        'id_cert_filename' => 'user_cert.pem',
-      }
-    end
-
-    it { is_expected.not_to contain_exec('pulp-auth') }
-  end
-
-  context 'with a password' do
-    let :params do
-      {
+        'login_method'     => 'none',
         'username'         => 'admin',
         'password'         => 'password',
         'id_cert_filename' => 'user_cert.pem',
       }
     end
 
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.not_to contain_exec('pulp-auth') }
+  end
+
+  context 'with login_method file' do
+    let :params do
+      {
+        'login_method'     => 'file',
+        'username'         => 'admin',
+        'password'         => 'password',
+        'id_cert_filename' => 'user_cert.pem',
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.not_to contain_exec('pulp-auth') }
+
+    it do
+      verify_exact_contents(catalogue, '/root/.pulp/admin.conf', [
+        '[auth]',
+        'username = admin',
+        'password = password',
+      ])
+    end
+  end
+
+  context 'with login_method login' do
+    let :params do
+      {
+        'login_method'     => 'login',
+        'username'         => 'admin',
+        'password'         => 'password',
+        'id_cert_filename' => 'user_cert.pem',
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+
     it do
       is_expected.to contain_exec('pulp-auth')
         .with_command('/usr/bin/pulp-admin login -u \'admin\' -p \'password\'')
         .with_creates('/root/.pulp/user_cert.pem')
+        .that_requires('File[/root/.pulp]')
     end
   end
 end

--- a/spec/classes/pulp_admin_login_spec.rb
+++ b/spec/classes/pulp_admin_login_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'pulp::admin::login' do
+  context 'with an undefined password' do
+    let :params do
+      {
+        'username'         => 'admin',
+        'password'         => '',
+        'id_cert_filename' => 'user_cert.pem',
+      }
+    end
+
+    it { is_expected.not_to contain_exec('pulp-auth') }
+  end
+
+  context 'with a password' do
+    let :params do
+      {
+        'username'         => 'admin',
+        'password'         => 'password',
+        'id_cert_filename' => 'user_cert.pem',
+      }
+    end
+
+    it do
+      is_expected.to contain_exec('pulp-auth')
+        .with_command('/usr/bin/pulp-admin login -u \'admin\' -p \'password\'')
+        .with_creates('/root/.pulp/user_cert.pem')
+    end
+  end
+end

--- a/templates/admin_home.conf.erb
+++ b/templates/admin_home.conf.erb
@@ -1,0 +1,3 @@
+[auth]
+username = <%= @username %>
+password = <%= @password %>


### PR DESCRIPTION
This refactoring relies on not having a SSLUsername (https://github.com/Katello/puppet-pulp/issues/138) so it's broken in the default deployment. You can create a /root/.pulp/admin.conf with the credentials hardcoded there as well. Would that be preferable?

It also looks like the providers need to be modified to get more autorequires for correct ordering.