### PR TITLE
Disable oauth by default

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,7 +32,7 @@ class pulp::params {
   $serial_number_path = '/var/lib/pulp/sn.dat'
 
   $consumer_history_lifetime = 180
-  $oauth_enabled = true
+  $oauth_enabled = false
   $oauth_key = 'pulp'
   $oauth_secret = 'secret'
 


### PR DESCRIPTION
OAuth has been deprecated since 2.4.0 and will be removed. We also have insecure defaults.

Closes GH-175