### PR TITLE
fixes #19740 - pulp_docker.conf schema 2

### DIFF
--- a/templates/etc/httpd/conf.d/pulp_docker.conf.erb
+++ b/templates/etc/httpd/conf.d/pulp_docker.conf.erb
@@ -15,6 +15,12 @@ Alias /pulp/docker/v2 /var/www/pub/docker/v2/web
     SSLRequireSSL
     Options FollowSymlinks Indexes
 </Directory>
+<Directory /var/www/pub/docker/v2/web/*/manifests/2>
+    Header set Docker-Distribution-API-Version "registry/2.0"
+    Header set Content-Type "application/vnd.docker.distribution.manifest.v2+json"
+    SSLRequireSSL
+    Options FollowSymlinks Indexes
+</Directory>
 
 # Docker v1
 Alias /pulp/docker/v1 /var/www/pub/docker/v1/web


### PR DESCRIPTION
correctly handle schema 2

To test, sync solr from docker hub then docker pull w/ docker-1.12 or higher