### PR TITLE
allow configuration of wsgi_processes and wsgi_max_requests

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -89,7 +89,14 @@ class pulp::apache {
       ssl_verify_depth           => '3',
       wsgi_process_group         => 'pulp',
       wsgi_application_group     => 'pulp',
-      wsgi_daemon_process        => 'pulp user=apache group=apache processes=3 display-name=%{GROUP}',
+      wsgi_daemon_process        => join([
+          'pulp',
+          'user=apache',
+          'group=apache',
+          "processes=${::pulp::wsgi_processes}",
+          "maximum-requests=${::pulp::wsgi_max_requests}",
+          'display-name=%{GROUP}',
+      ], ' '),
       wsgi_pass_authorization    => 'On',
       wsgi_import_script         => '/usr/share/pulp/wsgi/webservices.wsgi',
       wsgi_import_script_options => {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -232,6 +232,11 @@
 #
 # $max_keep_alive::             Configuration value for apache MaxKeepAliveRequests
 #
+# $wsgi_processes::             Number of WSGI processes to spown for pulp itself
+#
+# $wsgi_max_requests::          Maximum number of requests for each wsgi worker to process before
+#                               shutting down and restarting, useful to combat memory leaks.
+#
 # $puppet_wsgi_processes::      Number of WSGI processes to spawn for the puppet webapp
 #
 # $migrate_db_timeout::         Change the timeout for pulp-manage-db
@@ -349,6 +354,8 @@ class pulp (
   String $node_oauth_secret = $::pulp::params::node_oauth_secret,
   Array[String] $disabled_authenticators = $::pulp::params::disabled_authenticators,
   Hash[String, String] $additional_wsgi_scripts = $::pulp::params::additional_wsgi_scripts,
+  Integer[1] $wsgi_processes = $::pulp::params::wsgi_processes,
+  Integer[0] $wsgi_max_requests = $::pulp::params::wsgi_max_requests,
   Integer[0] $puppet_wsgi_processes = $::pulp::params::puppet_wsgi_processes,
   Integer[0] $migrate_db_timeout = $::pulp::params::migrate_db_timeout,
   Boolean $show_conf_diff = $::pulp::params::show_conf_diff,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -232,7 +232,7 @@
 #
 # $max_keep_alive::             Configuration value for apache MaxKeepAliveRequests
 #
-# $wsgi_processes::             Number of WSGI processes to spown for pulp itself
+# $wsgi_processes::             Number of WSGI processes to spawn for pulp itself
 #
 # $wsgi_max_requests::          Maximum number of requests for each wsgi worker to process before
 #                               shutting down and restarting, useful to combat memory leaks.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -112,6 +112,8 @@ class pulp::params {
 
   $yum_max_speed = undef
 
+  $wsgi_processes = 3
+  $wsgi_max_requests = 0
   $puppet_wsgi_processes = 3
   $show_conf_diff = false
 

--- a/spec/classes/pulp_apache_spec.rb
+++ b/spec/classes/pulp_apache_spec.rb
@@ -39,7 +39,7 @@ describe 'pulp::apache' do
         :ssl_verify_depth        => '3',
         :wsgi_process_group      => 'pulp',
         :wsgi_application_group  => 'pulp',
-        :wsgi_daemon_process     => 'pulp user=apache group=apache processes=3 display-name=%{GROUP}',
+        :wsgi_daemon_process     => 'pulp user=apache group=apache processes=3 maximum-requests=0 display-name=%{GROUP}',
         :wsgi_pass_authorization => 'On',
         :wsgi_import_script      => '/usr/share/pulp/wsgi/webservices.wsgi',
       })


### PR DESCRIPTION
We are having some issues with pulp's wsgi threads leaking memory, whether this is some low level python issue, something in django, or a bug in pulp itsef. The easiest way to mitigate it is just setting the "maximum-requests" parameter for the wsgi daemon¹.

Since I was adding a wsgi daemon parameter anyhow, I also decided to add a wsgi_processes option, since that looks like something people might want to tweak too.

¹ http://modwsgi.readthedocs.io/en/develop/configuration-directives/WSGIDaemonProcess.html