### PR TITLE
Allow katello/qpid 2.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -30,7 +30,7 @@
     },
     {
       "name": "katello/qpid",
-      "version_requirement": ">= 3.0.0 < 4.0.0"
+      "version_requirement": ">= 2.0.0 < 4.0.0"
     },
     {
       "name": "thias/squid3",


### PR DESCRIPTION
The module is fully compatible with 2.x.