### PR TITLE
Adding Pulp 2.14 changes

### DIFF
--- a/spec/classes/pulp_apache_spec.rb
+++ b/spec/classes/pulp_apache_spec.rb
@@ -236,6 +236,13 @@ Alias /pulp/docker/v2 /var/www/pub/docker/v2/web
     Options FollowSymlinks Indexes
 </Directory>
 
+<Directory /var/www/pub/docker/v2/web/*/manifests/list>
+    Header set Docker-Distribution-API-Version "registry/2.0"
+    Header set Content-Type "application/vnd.docker.distribution.manifest.list.v2+json"
+    SSLRequireSSL
+    Options FollowSymlinks Indexes
+</Directory>
+
 # Docker v1
 Alias /pulp/docker/v1 /var/www/pub/docker/v1/web
 <Directory /var/www/pub/docker/v1/web>
@@ -323,6 +330,7 @@ Alias /pulp/python /var/www/pub/python/
 
 <Directory /var/www/pub/python>
     Options FollowSymLinks Indexes
+    DirectoryIndex index.html index.json
 </Directory>
 ')
       end

--- a/spec/defines/pulp_apache_plugin_spec.rb
+++ b/spec/defines/pulp_apache_plugin_spec.rb
@@ -17,6 +17,7 @@ describe 'pulp::apache_plugin' do
         'Alias /pulp/python /var/www/pub/python/',
         '<Directory /var/www/pub/python>',
         '    Options FollowSymLinks Indexes',
+        '    DirectoryIndex index.html index.json',
         '</Directory>',
       ])
     end

--- a/templates/etc/httpd/conf.d/pulp_docker.conf.erb
+++ b/templates/etc/httpd/conf.d/pulp_docker.conf.erb
@@ -22,6 +22,13 @@ Alias /pulp/docker/v2 /var/www/pub/docker/v2/web
     Options FollowSymlinks Indexes
 </Directory>
 
+<Directory /var/www/pub/docker/v2/web/*/manifests/list>
+    Header set Docker-Distribution-API-Version "registry/2.0"
+    Header set Content-Type "application/vnd.docker.distribution.manifest.list.v2+json"
+    SSLRequireSSL
+    Options FollowSymlinks Indexes
+</Directory>
+
 # Docker v1
 Alias /pulp/docker/v1 /var/www/pub/docker/v1/web
 <Directory /var/www/pub/docker/v1/web>

--- a/templates/etc/httpd/conf.d/pulp_python.conf.erb
+++ b/templates/etc/httpd/conf.d/pulp_python.conf.erb
@@ -8,4 +8,5 @@ Alias /pulp/python /var/www/pub/python/
 
 <Directory /var/www/pub/python>
     Options FollowSymLinks Indexes
+    DirectoryIndex index.html index.json
 </Directory>


### PR DESCRIPTION
After laboriously going through the links below I identified the 2 files that had their config values updated with the release of pulp-2.14.  one is docker  and the other was python pep. This PR is meant to go in after 2.14 gets tagged to the nightly.

https://github.com/pulp/pulp/compare/2.13-release...2.14-release
https://github.com/pulp/pulp_rpm/compare/2.13-release...2.14-release

https://github.com/pulp/pulp_puppet/compare/2.13-release...2.14-release

https://github.com/pulp/pulp_docker/compare/2.4-release...3.0-release

https://github.com/pulp/pulp_ostree/compare/1.2-release...1.3-release

https://github.com/pulp/crane/compare/2.1-release...3.0-release

https://github.com/pulp/pulp_python/compare/1.0-release...2.0-release


