### PR TITLE
Allow repository management

### DIFF
--- a/examples/pulp_isorepo.pp
+++ b/examples/pulp_isorepo.pp
@@ -1,5 +1,5 @@
-class { '::pulp::repo::upstream': } ->
 class { '::pulp':
+  manage_repo  => true,
   # https://github.com/Katello/puppet-pulp/issues/138
   ssl_username => '',
   enable_admin => true,

--- a/examples/pulp_puppetrepo.pp
+++ b/examples/pulp_puppetrepo.pp
@@ -1,5 +1,5 @@
-class { '::pulp::repo::upstream': } ->
 class { '::pulp':
+  manage_repo   => true,
   # https://github.com/Katello/puppet-pulp/issues/138
   ssl_username  => '',
   enable_admin  => true,

--- a/examples/pulp_rpmrepo.pp
+++ b/examples/pulp_rpmrepo.pp
@@ -1,5 +1,5 @@
-class { '::pulp::repo::upstream': } ->
 class { '::pulp':
+  manage_repo  => true,
   # https://github.com/Katello/puppet-pulp/issues/138
   ssl_username => '',
   enable_admin => true,

--- a/examples/pulp_schedule.pp
+++ b/examples/pulp_schedule.pp
@@ -1,5 +1,5 @@
-class { '::pulp::repo::upstream': } ->
 class { '::pulp':
+  manage_repo  => true,
   # https://github.com/Katello/puppet-pulp/issues/138
   ssl_username => '',
   enable_admin => true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,8 @@
 #
 # $crane_data_dir::             Directory containing docker v1/v2 artifacts published by pulp
 #
+# $manage_repo::                Whether to manage the pulp repository
+#
 # $oauth_key::                  Key to enable OAuth style authentication
 #
 # $oauth_secret::               Shared secret that can be used for OAuth style authentication
@@ -263,6 +265,7 @@ class pulp (
   String $version = $::pulp::params::version,
   Boolean $crane_debug = $::pulp::params::crane_debug,
   Integer[1, 65535] $crane_port = $::pulp::params::crane_port,
+  Boolean $manage_repo = $::pulp::params::manage_repo,
   Stdlib::Absolutepath $crane_data_dir = $::pulp::params::crane_data_dir,
   String $db_name = $::pulp::params::db_name,
   String $db_seeds = $::pulp::params::db_seeds,
@@ -379,6 +382,11 @@ class pulp (
     assert_type(String, $ldap_url)
     assert_type(String, $ldap_bind_dn)
     assert_type(String, $ldap_bind_password)
+  }
+
+  if $manage_repo {
+    include ::pulp::repo::upstream
+    Class['pulp::repo::upstream'] -> Class['pulp::install']
   }
 
   include ::mongodb::client

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,6 +3,8 @@
 class pulp::params {
   $version = 'installed'
 
+  $manage_repo = false
+
   $db_name = 'pulp_database'
   $db_seeds = 'localhost:27017'
   $db_username = undef

--- a/spec/acceptance/admin_spec.rb
+++ b/spec/acceptance/admin_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper_acceptance'
 describe 'Scenario: pulp-admin' do
   let(:pp) do
     <<-EOS
-    class { '::pulp::repo::upstream': } ->
     class { '::pulp':
+      manage_repo => true,
       # https://github.com/Katello/puppet-pulp/issues/138
       ssl_username => '',
       enable_admin => true,

--- a/spec/acceptance/pulp_spec.rb
+++ b/spec/acceptance/pulp_spec.rb
@@ -3,8 +3,9 @@ require 'spec_helper_acceptance'
 describe 'Scenario: install pulp' do
   let(:pp) do
     <<-EOS
-    class { '::pulp::repo::upstream': } ->
-    class { '::pulp': }
+    class { '::pulp':
+      manage_repo => true,
+    }
     EOS
   end
 

--- a/spec/classes/pulp_spec.rb
+++ b/spec/classes/pulp_spec.rb
@@ -6,18 +6,26 @@ describe 'pulp' do
       on_supported_os['redhat-7-x86_64']
     end
 
-    it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_class('pulp::install') }
-    it { is_expected.to contain_class('pulp::config') }
-    it { is_expected.to contain_class('pulp::broker') }
-    it { is_expected.to contain_class('pulp::database') }
-    it { is_expected.to contain_class('pulp::apache') }
-    it { is_expected.to contain_class('pulp::service') }
+    context 'with default parameters' do
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.not_to contain_class('pulp::repo::upstream') }
+      it { is_expected.to contain_class('pulp::install') }
+      it { is_expected.to contain_class('pulp::config') }
+      it { is_expected.to contain_class('pulp::broker') }
+      it { is_expected.to contain_class('pulp::database') }
+      it { is_expected.to contain_class('pulp::apache') }
+      it { is_expected.to contain_class('pulp::service') }
 
-    services = ['Service[pulp_celerybeat]', 'Service[pulp_workers]', 'Service[pulp_resource_manager]', 'Service[pulp_streamer]']
-    it { is_expected.to contain_apache__vhost('pulp-https') }
-    it { is_expected.to contain_exec('migrate_pulp_db').that_notifies(services + ['Apache::Vhost[pulp-https]']) }
-    it { is_expected.to contain_service('mongodb').that_comes_before(services) }
-    it { is_expected.to contain_service('qpidd').that_comes_before(services) }
+      services = ['Service[pulp_celerybeat]', 'Service[pulp_workers]', 'Service[pulp_resource_manager]', 'Service[pulp_streamer]']
+      it { is_expected.to contain_apache__vhost('pulp-https') }
+      it { is_expected.to contain_exec('migrate_pulp_db').that_notifies(services + ['Apache::Vhost[pulp-https]']) }
+      it { is_expected.to contain_service('mongodb').that_comes_before(services) }
+      it { is_expected.to contain_service('qpidd').that_comes_before(services) }
+    end
+
+    context 'with manage_repo => true' do
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.not_to contain_class('pulp::repo::upstream').that_requires('Class[pulp::install]') }
+    end
   end
 end


### PR DESCRIPTION
This allows managing the repository. Currently it only allows using the upstream stable repository because the Katello repository isn't what most vanilla users expect and the Katello Installer typically expects it to already be enabled.

This flag is used to simplify our integration test.

Closes GH-164