### PR TITLE
Explicitly set ssl_certs_dir to an empty string

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -83,6 +83,7 @@ class pulp::apache {
       ssl_key                    => $::pulp::https_key,
       ssl_chain                  => $::pulp::https_chain,
       ssl_ca                     => $::pulp::ca_cert,
+      ssl_certs_dir              => '',
       ssl_verify_client          => 'optional',
       ssl_protocol               => $::pulp::ssl_protocol,
       ssl_options                => '+StdEnvVars +ExportCertData',

--- a/manifests/child/apache.pp
+++ b/manifests/child/apache.pp
@@ -30,6 +30,7 @@ class pulp::child::apache (
     ssl_cert               => $ssl_cert,
     ssl_key                => $ssl_key,
     ssl_ca                 => $ssl_ca,
+    ssl_certs_dir          => '',
     ssl_verify_client      => 'optional',
     ssl_options            => '+StdEnvVars',
     ssl_verify_depth       => '3',

--- a/manifests/crane/apache.pp
+++ b/manifests/crane/apache.pp
@@ -20,6 +20,7 @@ class pulp::crane::apache {
     ssl_key             => $::pulp::crane::key,
     ssl_chain           => $::pulp::crane::ca_cert,
     ssl_ca              => $::pulp::crane::ca_cert,
+    ssl_certs_dir       => '',
     ssl_verify_client   => 'optional',
     ssl_options         => '+StdEnvVars +ExportCertData +FakeBasicAuth',
     ssl_verify_depth    => '3',


### PR DESCRIPTION
Previously the SSLCACertificatePath would be set to the system certificate store thus accepting any certificate signed by a CA as valid client certificate.

puppetlabs-apache 1.11.1/2.1.0 will change this and assigned CVE-2017-2299 to it but this means we don't have to wait for that release and require the latest version.