### PR TITLE
Fix bad pulp_role example in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ class { '::pulp':
 	pulp_role { 'repo_admin':
 	  ensure      => 'present',
 	  users       => ['alice', 'bob'],
-	  permissions => {'/' => ['READ', 'CREATE'], '/pulp/api/v2/repositories/scl_ruby22_el7/' => ['READ', 'EXECUTE', 'UPDATE', 'CREATE', 'DELETE']},
+	  permissions => {'/' => ['READ', 'CREATE'], '/v2/repositories/scl_ruby22_el7/' => ['READ', 'EXECUTE', 'UPDATE', 'CREATE', 'DELETE']},
 	}
 
 ## Development


### PR DESCRIPTION
I'm a bit confused to open a PR for such a small change, but the example path in pulp_role example is wrong: it would silently not work as expected, and may be really misleading.

FYI, a few examples of valid paths for user permissions can be found [here](https://docs.pulpproject.org/dev-guide/integration/rest-api/permission/index.html)